### PR TITLE
CMake improvements: see if SDL2 target is defined; allow to build as a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.3.2)
 project(SDL_image C)
 
-if (ANDROID)
-
-else()
+if (NOT ANDROID AND NOT TARGET SDL2)
     find_package(SDL2 REQUIRED)
 endif()
 
@@ -13,7 +11,7 @@ option(SUPPORT_WEBP "Support loading WEBP images" OFF)
 option(BUILD_SHOWIMAGE "Build the showimage sample program" OFF)
 option(BUILD_SHARED_LIBS "Build the library as a shared library" ON)
 
-add_library(SDL2_image SHARED)
+add_library(SDL2_image)
 target_sources(SDL2_image PRIVATE IMG.c IMG_png.c IMG_bmp.c IMG_gif.c
 		IMG_jpg.c IMG_lbm.c IMG_pcx.c IMG_pnm.c IMG_svg.c IMG_tga.c
 		IMG_tif.c IMG_webp.c IMG_WIC.c IMG_xcf.c IMG_xpm.c IMG_xv.c IMG_xxx.c)


### PR DESCRIPTION
Hello.
This patch fixes two problems that I've encountered with SDL_image.

1) It didn't allow me to build it as a static library - `add_library` was called with `SHARED` flag, so `BUILD_SHARED_LIBS` had no effect.
2) I build SDL_image with SDL2 in a "superbuild" way by doing this:

```cmake
add_subdirectory(sdl2_src)
add_subdirectory(sdl_image_src)
```

Unfortunately, `find_package` didn't allow me to do it, because SDL2 was not found system-wide (it's not built when I call add_subdirectory). However, if you don't call `find_package` if `SDL2` target is present, this will work, because SDL2 will be compiled later and will successfully link with SDL_image afterwards.