### PR TITLE
More CMake fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ Release
 *.suo
 *.sdf
 *.opensdf
+
+# generated zlib files
+external/zlib-1.2.11/zconf.h
+external/zlib-1.2.11/zconf.h.included

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.3.2)
 project(SDL_image C)
 
-if (NOT ANDROID AND NOT TARGET SDL2)
-    find_package(SDL2 REQUIRED)
+if (NOT ANDROID AND NOT (TARGET SDL2 OR TARGET SDL2-static))
+	find_package(SDL2 REQUIRED)
 endif()
 
 option(SUPPORT_JPG "Support loading JPEG images" ON)
@@ -10,6 +10,10 @@ option(SUPPORT_PNG "Support loading PNG images" ON)
 option(SUPPORT_WEBP "Support loading WEBP images" OFF)
 option(BUILD_SHOWIMAGE "Build the showimage sample program" OFF)
 option(BUILD_SHARED_LIBS "Build the library as a shared library" ON)
+
+if (NOT BUILD_SHARED_LIBS)
+	set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
 
 add_library(SDL2_image)
 target_sources(SDL2_image PRIVATE IMG.c IMG_png.c IMG_bmp.c IMG_gif.c
@@ -31,15 +35,35 @@ if (SUPPORT_PNG)
 	set(HAVE_LD_VERSION_SCRIPT OFF CACHE BOOL "" FORCE)
 	target_compile_definitions(SDL2_image PRIVATE -DLOAD_PNG)
 
+  if (NOT TARGET zlib)
+	add_subdirectory(external/zlib-1.2.11 "${CMAKE_CURRENT_BINARY_DIR}/external/zlib-1.2.11")
+	set(ZLIB_INCLUDE_DIR "external/zlib-1.2.11")
+	set(SKIP_INSTALL_ALL ON) # SDL_image doesn't support installing currently
+	if (BUILD_SHARED_LIBS)
+		set(ZLIB_LIBRARY zlib)
+	else()
+		set(ZLIB_LIBRARY zlibstatic)
+	endif()
+	target_include_directories(${ZLIB_LIBRARY} PUBLIC
+		"${ZLIB_INCLUDE_DIR}"
+		"${CMAKE_CURRENT_BINARY_DIR}/external/zlib-1.2.11" # zconf.h is generated there
+	)
+  endif()
+
 	add_subdirectory(external/libpng-1.6.37)
 	include_directories(external/libpng-1.6.37)
-	target_link_libraries(SDL2_image PRIVATE png)
+	if(BUILD_SHARED_LIBS)
+		target_link_libraries(SDL2_image PRIVATE png)
+	else()
+		target_link_libraries(SDL2_image PRIVATE png_static)
+	endif()
 endif()
 
 if (SUPPORT_WEBP)
 	target_compile_definitions(SDL2_image PRIVATE -DLOAD_WEBP)
 	# missing cpufeatures
 	add_subdirectory(external/libwebp-1.0.3)
+	include_directories(external/libwebp-1.0.3/src)
 	target_link_libraries(SDL2_image PRIVATE webp)
 endif()
 
@@ -47,13 +71,16 @@ add_library(SDL2::image ALIAS SDL2_image)
 
 target_include_directories(SDL2_image PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-if (ANDROID)
-    target_link_libraries(SDL2_image PRIVATE SDL2)
+if (BUILD_SHARED_LIBS)
+	target_link_libraries(SDL2_image PUBLIC SDL2::SDL2)
 else()
-    target_link_libraries(SDL2_image PRIVATE SDL2::SDL2)
+	target_link_libraries(SDL2_image PUBLIC SDL2::SDL2-static)
 endif()
 
 if(BUILD_SHOWIMAGE)
 	add_executable(showimage showimage.c)
-	target_link_libraries(showimage PRIVATE SDL2::SDL2 SDL2::image)
+	target_link_libraries(showimage PRIVATE SDL2::image)
+	if (WIN32)
+		target_link_libraries(showimage PRIVATE SDL2::SDL2main)
+	endif()
 endif()

--- a/external/jpeg-9d/CMakeLists.txt
+++ b/external/jpeg-9d/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.3.2)
 project(jpeg C)
 
-add_library(jpeg SHARED)
+add_library(jpeg)
 target_sources(jpeg PRIVATE
 		jaricom.c jcapimin.c jcapistd.c jcarith.c jccoefct.c jccolor.c
 		jcdctmgr.c jchuff.c jcinit.c jcmainct.c jcmarker.c jcmaster.c
@@ -10,8 +10,13 @@ target_sources(jpeg PRIVATE
 		jddctmgr.c jdhuff.c jdinput.c jdmainct.c jdmarker.c jdmaster.c
 		jdmerge.c jdpostct.c jdsample.c jdtrans.c jerror.c jfdctflt.c
 		jfdctfst.c jfdctint.c jidctflt.c jquant1.c
-		jquant2.c jutils.c jmemmgr.c
-		jmem-android.c)
+		jquant2.c jutils.c jmemmgr.c)
+
+if (ANDROID)
+	target_sources(jpeg PRIVATE jmem-android.c)
+else()
+	target_sources(jpeg PRIVATE jmemansi.c)
+endif()
 
 
 target_sources(jpeg PRIVATE jidctint.c jidctfst.c)


### PR DESCRIPTION
Hello. This patch is a lot more complex than my previous CMake one, but it's not possible to fix only one thing at a time, unfortunately.

Currently, the CMake build is broken in several places and here's what this patch does:

* Link to a correct SDL target depending on build type (static or shared)
* Link to a correct libpng target based on the build type
* Fix libjpeg build (`jmemansi.c` wasn't included in the build)
* Fix showimage build on Windows - need to link to SDL2main
* Use bundled zlib for build
* Fix webp build (it doesn't add needed include directory for some reason)
* Add zconf.h to gitignore - maybe it should be deleted from the repo even? It's generated during the build of zlib in the binary dir. And zlib's CMake renames `zconf.h` to `zconf.h.included` in the source directory, which is annoying and can't be prevented...

Dynamic linking doesn't work on Windows with `SUPPORT_WEBP=ON`, because libwebp doesn't define `WEBP_EXTERN` as `__declspec(dllexport)` - I didn't find a way to fix it yet, unfortunately (maybe the issue should be created so that we don't forget about it?)

P.S. In the next patches it will be good to add ability for user to link their own libpng, libz, libjpeg and libwebp if they want to. I currently build them myself and it's currently impossible to force SDL_image to link to them instead of bundled ones.