### PR TITLE
showimage: Add a -quit option

### DIFF
--- a/showimage.c
+++ b/showimage.c
@@ -54,7 +54,8 @@ int main(int argc, char *argv[])
     SDL_Renderer *renderer;
     SDL_Texture *texture;
     Uint32 flags;
-    int i, w, h, done;
+    int i, w, h;
+    int done = 0;
     SDL_Event event;
     const char *saveFile = NULL;
 
@@ -84,6 +85,11 @@ int main(int argc, char *argv[])
 
     for ( i=1; argv[i]; ++i ) {
         if ( SDL_strcmp(argv[i], "-fullscreen") == 0 ) {
+            continue;
+        }
+
+        if ( SDL_strcmp(argv[i], "-quit") == 0 ) {
+            done = 1;
             continue;
         }
 
@@ -127,7 +133,6 @@ int main(int argc, char *argv[])
         SDL_SetWindowSize(window, w, h);
         SDL_ShowWindow(window);
 
-        done = 0;
         while ( ! done ) {
             while ( SDL_PollEvent(&event) ) {
                 switch (event.type) {


### PR DESCRIPTION
This allows showimage to be used as a non-interactive smoke-test to
check that the SDL2_image library can be linked against successfully,
for example as used in the Steam Runtime:

    xvfb-run ./showimage -quit -save debian-logo.bmp /usr/share/pixmaps/debian-logo.png

---

We've been applying this in the Steam Runtime for a while, and using it in an [autopkgtest script](https://salsa.debian.org/ci-team/autopkgtest/blob/master/doc/README.package-tests.rst) (the command-line quoted is a simplified version of the real script). I'd like to do the same in Debian proper, but I'd feel more comfortable about that if this change was applied upstream.