### PR TITLE
Fix cmake build for git submodules on unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,20 +51,23 @@ if (SUPPORT_PNG)
 	set(HAVE_LD_VERSION_SCRIPT OFF CACHE BOOL "" FORCE)
 	target_compile_definitions(SDL2_image PRIVATE -DLOAD_PNG)
 
-  if (NOT TARGET zlib)
-	add_subdirectory(external/zlib-1.2.11 "${CMAKE_CURRENT_BINARY_DIR}/external/zlib-1.2.11")
-	set(ZLIB_INCLUDE_DIR "external/zlib-1.2.11")
-	set(SKIP_INSTALL_ALL ON) # SDL_image doesn't support installing currently
-	if (BUILD_SHARED_LIBS)
-		set(ZLIB_LIBRARY zlib)
-	else()
-		set(ZLIB_LIBRARY zlibstatic)
+	if (NOT TARGET zlib)
+		# if zlib not included from another source, add_subdirectory
+		add_subdirectory(external/zlib-1.2.11)
+
+		# libpng find_package(zlib) requires ZLIB_INCLUDE_DIR set
+		get_target_property(ZLIB_INCLUDE_DIR zlib INCLUDE_DIRECTORIES)
+
+		# libpng find_package(zlib) requires ZLIB_LIBRARY
+		if (BUILD_SHARED_LIBS)
+			set(ZLIB_LIBRARY zlib)
+		else()
+			set(ZLIB_LIBRARY zlibstatic)
+		endif()
+
+		# SDL_image doesn't support installing currently
+		set(SKIP_INSTALL_ALL ON)
 	endif()
-	target_include_directories(${ZLIB_LIBRARY} PUBLIC
-		"${ZLIB_INCLUDE_DIR}"
-		"${CMAKE_CURRENT_BINARY_DIR}/external/zlib-1.2.11" # zconf.h is generated there
-	)
-  endif()
 
 	add_subdirectory(external/libpng-1.6.37)
 	include_directories(external/libpng-1.6.37)

--- a/external/zlib-1.2.11/CMakeLists.txt
+++ b/external/zlib-1.2.11/CMakeLists.txt
@@ -83,7 +83,7 @@ configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/zlib.pc.cmakein
 		${ZLIB_PC} @ONLY)
 configure_file(	${CMAKE_CURRENT_SOURCE_DIR}/zconf.h.cmakein
 		${CMAKE_CURRENT_BINARY_DIR}/zconf.h @ONLY)
-include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 
 #============================================================================


### PR DESCRIPTION
CMake build when including SDL_image as git submodule was broken for unix:
```
$ make
[  1%] Generating pnglibconf.c
[  2%] Generating pnglibconf.out
/home/cvarner/workspace/game-template/build/external/SDL_image/external/libpng-1.6.37/pnglibconf.c:34:11: fatal error: zlib.h: No such file or directory
   34 | # include <zlib.h>
      |           ^~~~~~~~
compilation terminated.
CMake Error at scripts/genout.cmake:78 (message):
  Failed to generate
  /home/cvarner/workspace/game-template/build/external/SDL_image/external/libpng-1.6.37/pnglibconf.out.tf1
```
looking at the `scripts/genout.cmake` created by cmake, you can see how the includes are generated
```
set(INCDIR "/home/cvarner/workspace/game-template/build/external/SDL_image/external/libpng-1.6.37")
...
set(ZLIBINCDIR "external/zlib-1.2.11")    <--- this comes from ZLIB_INCLUDE_DIR
...
  set(INCLUDES "-I${INCDIR}")
  if(ZLIBINCDIR)
    foreach(dir ${ZLIBINCDIR})
      list(APPEND INCLUDES "-I${dir}")
    endforeach()
  endif()
```
which results in the following compile commands while compiling the generated file `pnglibconf.c`:
```
cd /home/cvarner/workspace/game-template/build/external/SDL_image/external/libpng-1.6.37
/usr/bin/cc' '-E'
'-I/home/cvarner/workspace/game-template/external/SDL_image/external/libpng-1.6.37'
'-I/home/cvarner/workspace/game-template/build/external/SDL_image/external/libpng-1.6.37'
'-I/home/cvarner/workspace/game-template/build/external/SDL_image/external/libpng-1.6.37'
'-Iexternal/zlib-1.2.11'
'-DPNGLIB_LIBNAME=PNG16_0'
'-DPNGLIB_VERSION=1.6.37'
'-DSYMBOL_PREFIX='
'-DPNG_NO_USE_READ_MACROS'
'-DPNG_BUILDING_SYMBOL_TABLE'
'/home/cvarner/workspace/game-template/build/external/SDL_image/external/libpng-1.6.37/pnglibconf.c
```
Note that the relative include "external/zlib-1.2.11" resolves to `/home/cvarner/workspace/game-template/external/SDL_image/external/libpng-1.6.37/external/zlib-1.2.11` instead of the zlib source, causing the original error.

Updating the top level CMakeLists.txt to use an absolute path results in the following compile command, which is better
```
'/usr/bin/cc'
'-E'
'-I/home/cvarner/workspace/game-template/external/SDL_image/external/libpng-1.6.37'
'-I/home/cvarner/workspace/game-template/build/external/SDL_image/external/libpng-1.6.37'
'-I/home/cvarner/workspace/game-template/build/external/SDL_image/external/libpng-1.6.37'
'-I/home/cvarner/workspace/game-template/external/SDL_image/external/zlib-1.2.11'
'-DPNGLIB_LIBNAME=PNG16_0' '-DPNGLIB_VERSION=1.6.37' '-DSYMBOL_PREFIX=' '-DPNG_NO_USE_READ_MACROS' '-DPNG_BUILDING_SYMBOL_TABLE'
'/home/cvarner/workspace/game-template/build/external/SDL_image/external/libpng-1.6.37/pnglibconf.c'
```
We are still missing zlib's output directory though so we get the following error:
```
/home/cvarner/workspace/game-template/external/SDL_image/external/zlib-1.2.11/zlib.h:34:10: fatal error: zconf.h: No such file or directory
   34 | #include "zconf.h"
      |          ^~~~~~~~~
compilation terminated.
CMake Error at scripts/genout.cmake:79 (message):
  Failed to generate
  /home/cvarner/workspace/game-template/build/external/SDL_image/external/libpng-1.6.37/pnglibconf.out.tf1
```
zlibs include directories should include both the original source and the binary dir. This PR does that with 2 changes:

1) https://github.com/madler/zlib/issues/218 is a long standing zlib issue with a known solution https://github.com/madler/zlib/pull/219 that only appears to remain unfixed because the repo hasn't been updated since 2017.

2) With (1) fixed, ZLIB_INCLUDE_DIR can be set using the `INCLUDE_DIRECTORIES` property of the zlib target created by adding the zlib subdirectory. This variable now correctly contains all include directories resulting in the following compile command:

```
'/usr/bin/cc' '-E'
'-I/home/cvarner/workspace/game-template/external/SDL_image_fork/external/libpng-1.6.37'
'-I/home/cvarner/workspace/game-template/build/external/SDL_image_fork/external/libpng-1.6.37'
'-I/home/cvarner/workspace/game-template/build/external/SDL_image_fork/external/libpng-1.6.37'
'-I/home/cvarner/workspace/game-template/build/external/SDL_image_fork/external/zlib-1.2.11'
'-I/home/cvarner/workspace/game-template/external/SDL_image_fork/external/zlib-1.2.11'
'-DPNGLIB_LIBNAME=PNG16_0'
'-DPNGLIB_VERSION=1.6.37'
'-DSYMBOL_PREFIX='
'-DPNG_NO_USE_READ_MACROS'
'-DPNG_BUILDING_SYMBOL_TABLE'
'/home/cvarner/workspace/game-template/build/external/SDL_image_fork/external/libpng-1.6.37/pnglibconf.c'
```
The build succeeds with no issues from there on