### PR TITLE
Adding PIC for compiling with cmake on Unix-like

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ if (NOT BUILD_SHARED_LIBS)
 	set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
+if (NOT WINDOWS)
+	add_compile_options(-fPIC)
+endif()
+
 add_library(SDL2_image)
 
 set(IMAGEIO_SOURCES)


### PR DESCRIPTION
By default sdl2 and sdl2_image compile static and dynamic using cmake, but when working on Linux x86_64 and adding sdl2 and sdl2_image source directory into my CMakeLists.txt using: add_subdirectory i get the error  when the Linker try to link the previous objects into the `libSDL2_image.so`: 

![Screenshot_2021-08-17_13-20-20](https://user-images.githubusercontent.com/42550884/129765154-856b7195-7407-435a-80e4-1f82e4f9873b.png)

The error message tells to add -fPIC(since windows works with dll, i don't know if this is an problem) onto `SDL_image/CMakelits.txt`:

![Screenshot_2021-08-17_13-42-03](https://user-images.githubusercontent.com/42550884/129766482-dcfcd55e-10f7-49cd-8be8-d00f500b6c47.png)

So, adding the code:
```
if (NOT WINDOWS)
	add_compile_options(-fPIC)
endif()
```
above `add_library(SDL2_image)` in SDL2_image/CMakeLists.txt solves this problem.
Now it works: 

![Screenshot_2021-08-17_13-50-48](https://user-images.githubusercontent.com/42550884/129767885-efc93cf4-23fb-4f7f-8689-e00e4640d9bc.png)
