### PR TITLE
gif: Don't import internal function IMG_LoadGIF_RW_Internal

### DIFF
--- a/IMG_gif.c
+++ b/IMG_gif.c
@@ -199,7 +199,7 @@ static SDL_bool NormalizeFrames(Frame_t *frames, int count)
     return SDL_TRUE;
 }
 
-Anim_t *
+static Anim_t *
 IMG_LoadGIF_RW_Internal(SDL_RWops *src, SDL_bool load_anim)
 {
     unsigned char buf[16];


### PR DESCRIPTION
This isn't mentioned in the header file and it returns a type that
callers cannot understand without knowing internal implementation
details, so I assume it was meant to be private to SDL_image.