### PR TITLE
showanim: Add a command-line option to loop once and then exit

### DIFF
--- a/showanim.c
+++ b/showanim.c
@@ -56,6 +56,7 @@ int main(int argc, char *argv[])
     SDL_Texture **textures;
     Uint32 flags;
     int i, j, w, h, done;
+    int once = 0;
     int current_frame, delay;
     SDL_Event event;
 
@@ -85,6 +86,11 @@ int main(int argc, char *argv[])
 
     for ( i=1; argv[i]; ++i ) {
         if ( SDL_strcmp(argv[i], "-fullscreen") == 0 ) {
+            continue;
+        }
+
+        if ( SDL_strcmp(argv[i], "-once") == 0 ) {
+            once = 1;
             continue;
         }
 
@@ -168,6 +174,10 @@ int main(int argc, char *argv[])
             SDL_Delay(delay);
 
             current_frame = (current_frame + 1) % anim->count;
+
+            if (once && current_frame == 0) {
+                break;
+            }
         }
 
         for (j = 0; j < anim->count; ++j) {


### PR DESCRIPTION
Similar to showimage -quit, this allows it to be used as a
non-interactive smoke-test.