### PR TITLE
Update IMG_Init() return value to match documentation

### DIFF
--- a/IMG.c
+++ b/IMG.c
@@ -87,11 +87,6 @@ int IMG_Init(int flags)
 {
     int result = 0;
 
-    /* Passing 0 returns the currently initialized loaders */
-    if (!flags) {
-        return initialized;
-    }
-
     if (flags & IMG_INIT_JPG) {
         if ((initialized & IMG_INIT_JPG) || IMG_InitJPG() == 0) {
             result |= IMG_INIT_JPG;
@@ -114,7 +109,7 @@ int IMG_Init(int flags)
     }
     initialized |= result;
 
-    return result;
+    return initialized;
 }
 
 void IMG_Quit()


### PR DESCRIPTION
The documentation here: https://www.libsdl.org/projects/SDL_image/docs/SDL_image_8.html seems to indicate that the return value of IMG_Init() should be:

```
Returns: a bitmask of all the currently initted image loaders. 
```

This change updates the behavior to match this. With this change, if IMG_Init is called with a single flag set, but other loaders had already been initialized, they will be indicated as initialized in the return value.