### PR TITLE
fix #206 (png-saving for RGB24 and palette with transparent)

### DIFF
--- a/IMG_png.c
+++ b/IMG_png.c
@@ -513,7 +513,7 @@ static int IMG_SavePNG_RW_libpng(SDL_Surface *surface, SDL_RWops *dst, int freed
         png_structp png_ptr;
         png_infop info_ptr;
         png_colorp color_ptr = NULL;
-        uint8_t transparent_table[256];
+        Uint8 transparent_table[256];
         SDL_Surface *source = surface;
         SDL_Palette *palette;
         int png_color_type = PNG_COLOR_TYPE_RGB_ALPHA;


### PR DESCRIPTION
Add support for saving `tRNS chunk` (transparency for palette)
No convertion `RGB24` -> `RGBA32`, if we can just save `RGB24` (good for saving speed and file size)

Also I recommend you make small (or not) refactoring of file `IMG_png.c` in the future
For example, last 5 lines of `IMG_SavePNG_RW_libpng` or all code of `IMG_SavePNG_RW` writed in bad style