### PR TITLE
[WINCE] Fix detection of WINDRES

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,12 +52,7 @@ AC_PROG_OBJC
 AC_C_INLINE
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
-if test -z "$host_alias"; then
-    hostaliaswindres=
-else
-    hostaliaswindres="$host_alias-windres"
-fi
-AC_CHECK_PROGS(WINDRES, [windres $hostaliaswindres $host_os-windres])
+AC_CHECK_TOOL(WINDRES, [windres], [:])
 
 case "$host" in
     *-*-beos*)


### PR DESCRIPTION
I tried to build with arm-mingw32ce cross compiler and I got this error:

```
arm-mingw32ce-gcc -shared  .libs/IMG.o .libs/IMG_bmp.o .libs/IMG_gif.o .libs/IMG_jpg.o .libs/IMG_lbm.o .libs/IMG_pcx.o .libs/IMG_png.o .libs/IMG_pnm.o .libs/IMG_tga.o .libs/IMG_tif.o .libs/IMG_xcf.o .libs/IMG_xpm.o .libs/IMG_xv.o .libs/IMG_webp.o   /opt/cegcc/arm-mingw32ce/lib/libSDLmain.a /opt/cegcc/arm-mingw32ce/lib/libSDL.dll.a -lmmtimer -lcoredll -lcommctrl  -Wl,version.o   -o .libs/SDL_image.dll -Wl,--enable-auto-image-base -Xlinker --out-implib -Xlinker .libs/libSDL_image.dll.a
version.o: file not recognized: file format not recognized
collect2: error: ld returned 1 exit status
```

This happened because `version.o` has been compiled with the WINDRES provided by CYGWIN instead of using `arm-mingw32ce-windres`.
I would like to suggest to import the same code used by SDL-1.2 for detecting WINDRES.
By applying this fix, the problem has been solved.
Tested with:
* x86_64-pc-cygwin
* x86_64-w64-mingw32
* i686-w64-mingw32
* arm-mingw32ce

Perhaps, if you think that it is a good fix, it would be worth to import it also in the main branch.