### PR TITLE
configure.ac: Use Autoconf quadrigraphs for character set in AS_CASE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_SUBST([MICRO_VERSION], MICRO_VERSION_MACRO)
 
 BINARY_AGE=`expr $MINOR_VERSION \* 100 + $MICRO_VERSION`
 AS_CASE(["$MINOR_VERSION"],
-  [*[02468]],
+  [*@<:@02468@:>@],
     dnl Stable branch, 2.6.1 -> libSDL2-2.0.so.0.600.1
     [INTERFACE_AGE="$MICRO_VERSION"],
   [*],


### PR DESCRIPTION
The use of square brackets for a character set collides with the use
of square brackets for m4 quote characters, so use the other quoting
mechanism that Autoconf provides, by escaping [ as @<:@ and so on.

---

Same as libsdl-org/SDL#5620.

@slouken, @sezero: After merging, please regenerate the Autotools goo.