### PR TITLE
Change CMake export name + allow parallel installs of static/shared SDL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,6 @@ option(SUPPORT_XV "Support loading XV images" ON)
 
 option(BUILD_SAMPLES "Build the SDL2_image sample program(s)" ON)
 option(BUILD_SHARED_LIBS "Build the library as a shared library" ON)
-
 # FIXME: use vendored libavif when available
 set(SUPPORT_AVIF_VENDORED OFF)
 #cmake_dependent_option(SUPPORT_AVIF_VENDORED "Use vendored libavif" ${VENDORED_DEFAULT} SUPPORT_AVIF OFF)
@@ -293,6 +292,14 @@ if (NOT BUILD_SHARED_LIBS)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
+if(BUILD_SHARED_LIBS)
+    set(sdl2_image_export_name SDL2_image)
+    set(sdl2_image_install_name_infix shared)
+else()
+    set(sdl2_image_export_name SDL2_image-static)
+    set(sdl2_image_install_name_infix static)
+endif()
+
 add_library(SDL2_image
     IMG.c
     IMG_avif.c
@@ -316,7 +323,7 @@ add_library(SDL2_image
     IMG_xv.c
     IMG_xxx.c
     )
-add_library(SDL2_image::SDL2_image ALIAS SDL2_image)
+add_library(SDL2_image::${sdl2_image_export_name} ALIAS SDL2_image)
 
 target_compile_definitions(SDL2_image PRIVATE
     SDL_BUILD_MAJOR_VERSION=${MAJOR_VERSION}
@@ -352,13 +359,17 @@ endif()
 
 set(INSTALL_EXTRA_TARGETS)
 set(PC_REQUIRES)
+set(PC_LIBS)
 
 if (SUPPORT_AVIF)
     target_compile_definitions(SDL2_image PRIVATE LOAD_AVIF)
     if (SUPPORT_AVIF_VENDORED)
         message(FATAL_ERROR "libavif is not vendored yet")
         add_subdirectory(external/libavif EXCLUDE_FROM_ALL)
-        # list(APPEND INSTALL_EXTRA_TARGETS libavif)
+        list(APPEND INSTALL_EXTRA_TARGETS libavif)
+        if (NOT SUPPORT_AVIF_SHARED)
+            list(APPEND PC_LIBS -l$<TARGET_FILE_BASE_NAME:avif>)
+        endif()
     else()
         find_package(libavif REQUIRED)
         list(APPEND PC_REQUIRES libavif)
@@ -396,6 +407,9 @@ if (SUPPORT_JPG)
             add_subdirectory(external/jpeg EXCLUDE_FROM_ALL)
             add_library(JPEG::JPEG ALIAS jpeg)
             list(APPEND INSTALL_EXTRA_TARGETS jpeg)
+            if (NOT SUPPORT_JPG_SHARED)
+                list(APPEND PC_LIBS -l$<TARGET_FILE_BASE_NAME:jpeg>)
+            endif()
         else()
             find_package(JPEG REQUIRED)
             list(APPEND PC_REQUIRES libjpeg)
@@ -426,6 +440,11 @@ if (SUPPORT_JXL)
         if (BUILD_SHARED_LIBS)
             set(jxl_lib jxl)
             list(APPEND INSTALL_EXTRA_TARGETS brotlidec brotlicommon brotlienc ${jxl_lib})
+            if (NOT SUPPORT_JXL_SHARED)
+                list(APPEND PC_LIBS
+                    -l$<TARGET_FILE_BASE_NAME:brotlidec> -l$<TARGET_FILE_BASE_NAME:brotlicommon>
+                    -l$<TARGET_FILE_BASE_NAME:brotlienc> -l$<TARGET_FILE_BASE_NAME:${jxl_lib}>)
+            endif()
         else()
             set(jxl_lib jxl-static)
             list(APPEND INSTALL_EXTRA_TARGETS brotlidec-static brotlicommon-static brotlienc-static hwy ${jxl_lib})
@@ -487,6 +506,9 @@ if (SUPPORT_PNG)
                     set(ZLIB_LIBRARY zlibstatic)
                 endif()
                 list(APPEND INSTALL_EXTRA_TARGETS ${ZLIB_LIBRARY})
+                if (NOT SUPPORT_PNG_SHARED)
+                    list(APPEND PC_LIBS -l$<TARGET_FILE_BASE_NAME:${ZLIB_LIBRARY}>)
+                endif()
             endif()
             set(SKIP_INSTALL_EXPORT ON)
             add_subdirectory(external/libpng EXCLUDE_FROM_ALL)
@@ -498,6 +520,9 @@ if (SUPPORT_PNG)
             add_library(PNG::PNG ALIAS ${PNG_LIBRARY})
             target_include_directories(SDL2_image PRIVATE external/libpng)
             list(APPEND INSTALL_EXTRA_TARGETS ${PNG_LIBRARY})
+            if (NOT SUPPORT_PNG_SHARED)
+                list(APPEND PC_LIBS -l$<TARGET_FILE_BASE_NAME:${PNG_LIBRARY}>)
+            endif()
         else()
             find_package(PNG REQUIRED)
             list(APPEND PC_REQUIRES libpng)
@@ -543,6 +568,9 @@ if (SUPPORT_TIF)
         add_subdirectory(external/libtiff EXCLUDE_FROM_ALL)
         add_library(TIFF::TIFF ALIAS tiff)
         list(APPEND INSTALL_EXTRA_TARGETS tiff)
+        if (NOT SUPPORT_TIF_SHARED)
+            list(APPEND PC_LIBS -l$<TARGET_FILE_BASE_NAME:tiff>)
+        endif()
     else()
         find_package(TIFF REQUIRED)
         list(APPEND PC_REQUIRES libtiff-4)
@@ -626,7 +654,7 @@ target_include_directories(SDL2_image
 set_target_properties(SDL2_image PROPERTIES
     DEFINE_SYMBOL DLL_EXPORT
     PUBLIC_HEADER SDL_image.h
-    EXPORT_NAME SDL2_image
+    EXPORT_NAME ${sdl2_image_export_name}
     C_VISIBILITY_PRESET "hidden"
     )
 if (UNIX AND NOT APPLE AND NOT ANDROID)
@@ -670,7 +698,7 @@ if (NOT SDL2_IMAGE_DISABLE_INSTALL)
             )
     endif()
 
-    configure_package_config_file(SDL2_image-config.cmake.in SDL2_image-config.cmake
+    configure_package_config_file(SDL2_imageConfig.cmake.in SDL2_imageConfig.cmake
         INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2_image")
 
     set(prefix "${CMAKE_INSTALL_PREFIX}")
@@ -681,11 +709,11 @@ if (NOT SDL2_IMAGE_DISABLE_INSTALL)
     set(VERSION "${FULL_VERSION}")
     set(SDL_VERSION "${SDL_REQUIRED_VERSION}")
     string(JOIN " " PC_REQUIRES ${PC_REQUIRES})
-    file(GENERATE OUTPUT SDL2_image.pc INPUT SD2_image.pc.in)
+    file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/SDL2_image.pc" INPUT "${PROJECT_SOURCE_DIR}/SDL2_image.pc.in")
 
     install(EXPORT SDL2ImageExports NAMESPACE SDL2_image::
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2_image" FILE SDL2_image-targets.cmake)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SDL2_image-config.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2_image")
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2_image" FILE SDL2_image-${sdl2_image_install_name_infix}-targets.cmake)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SDL2_imageConfig.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2_image")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SDL2_image.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
     install(FILES "LICENSE.txt" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/licenses/${PROJECT_NAME}")
     if (NOT (WIN32 OR CYGWIN OR MINGW))
@@ -712,7 +740,7 @@ if (BUILD_SAMPLES)
             target_link_libraries(${prog} PRIVATE mingw32)
             target_link_options(${prog} PRIVATE -mwindows)
         endif()
-        target_link_libraries(${prog} PRIVATE SDL2_image::SDL2_image)
+        target_link_libraries(${prog} PRIVATE SDL2_image::${sdl2_image_export_name})
         if (TARGET SDL2::SDL2main)
             target_link_libraries(${prog} PRIVATE SDL2::SDL2main)
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,6 +234,7 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
 option(VENDORED_DEFAULT "Default value for *_VENDORED options. Can be overridden for each library. Is only used in the first configure run." ON)
+option(SDL2_IMAGE_DISABLE_INSTALL "Disable installing SDL2_image" OFF)
 
 option(BACKEND_STB "Use stb_image for loading JPEG and PNG files" ON)
 cmake_dependent_option(BACKEND_WIC "Add WIC backend (Windows Imaging Component)" OFF "WIN32" OFF)
@@ -315,7 +316,7 @@ add_library(SDL2_image
     IMG_xv.c
     IMG_xxx.c
     )
-add_library(SDL2::image ALIAS SDL2_image)
+add_library(SDL2_image::SDL2_image ALIAS SDL2_image)
 
 target_compile_definitions(SDL2_image PRIVATE
     SDL_BUILD_MAJOR_VERSION=${MAJOR_VERSION}
@@ -646,56 +647,58 @@ if (BUILD_SHARED_LIBS)
     endif()
 endif()
 
-if (BUILD_SHARED_LIBS)
-    target_link_libraries(SDL2_image PRIVATE SDL2::SDL2)
-else()
-    target_link_libraries(SDL2_image PRIVATE SDL2::SDL2-static)
-endif()
+if (NOT SDL2_IMAGE_DISABLE_INSTALL)
+    if (BUILD_SHARED_LIBS)
+        target_link_libraries(SDL2_image PRIVATE SDL2::SDL2)
+    else()
+        target_link_libraries(SDL2_image PRIVATE SDL2::SDL2-static)
+    endif()
 
-install(TARGETS SDL2_image EXPORT SDL2ImageExports
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/SDL2"
-    )
-
-if (INSTALL_EXTRA_TARGETS)
-    install(TARGETS ${INSTALL_EXTRA_TARGETS} EXPORT SDL2ImageExports
+    install(TARGETS SDL2_image EXPORT SDL2ImageExports
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        PUBLIC_HEADER DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/external_include"
+        PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/SDL2"
         )
-endif()
 
-configure_package_config_file(SDL2_image-config.cmake.in SDL2_image-config.cmake
-    INSTALL_DESTINATION "${CMAKE_INSTALL_LBDIR}/cmake/SDL2_image")
+    if (INSTALL_EXTRA_TARGETS)
+        install(TARGETS ${INSTALL_EXTRA_TARGETS} EXPORT SDL2ImageExports
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            PUBLIC_HEADER DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/external_include"
+            )
+    endif()
 
-set(prefix "${CMAKE_INSTALL_PREFIX}")
-set(exec_prefix "${CMAKE_INSTALL_FULL_LIBEXECDIR}")
-set(libdir "${CMAKE_INSTALL_FULL_LIBDIR}")
-set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
-set(PACKAGE "${PROJECT_NAME}")
-set(VERSION "${FULL_VERSION}")
-set(SDL_VERSION "${SDL_REQUIRED_VERSION}")
-string(JOIN " " PC_REQUIRES ${PC_REQUIRES})
-configure_file(SDL2_image.pc.in SDL2_image.pc @ONLY)
+    configure_package_config_file(SDL2_image-config.cmake.in SDL2_image-config.cmake
+        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2_image")
 
-install(EXPORT SDL2ImageExports NAMESPACE SDL2::
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2_image" FILE SDL2_image-targets.cmake)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SDL2_image-config.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2_image")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SDL2_image.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-install(FILES "LICENSE.txt" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/licenses/${PROJECT_NAME}")
-if (NOT (WIN32 OR CYGWIN OR MINGW))
-    if(BUILD_SHARED_LIBS)
-        set(SOEXT ${CMAKE_SHARED_LIBRARY_SUFFIX}) # ".so", ".dylib", etc.
-        get_target_property(SONAME SDL2_image OUTPUT_NAME)
-        if(NOT ANDROID)
-            install(CODE "
-				execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
-					\"lib${SONAME}${SOEXT}\" \"libSDL2_image${SOEXT}\"
-					WORKING_DIRECTORY \"${PROJECT_BINARY_DIR}\")")
-            install(FILES ${PROJECT_BINARY_DIR}/libSDL2_image${SOEXT} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+    set(prefix "${CMAKE_INSTALL_PREFIX}")
+    set(exec_prefix "\${prefix}")
+    set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+    set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+    set(PACKAGE "${PROJECT_NAME}")
+    set(VERSION "${FULL_VERSION}")
+    set(SDL_VERSION "${SDL_REQUIRED_VERSION}")
+    string(JOIN " " PC_REQUIRES ${PC_REQUIRES})
+    file(GENERATE OUTPUT SDL2_image.pc INPUT SD2_image.pc.in)
+
+    install(EXPORT SDL2ImageExports NAMESPACE SDL2_image::
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2_image" FILE SDL2_image-targets.cmake)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SDL2_image-config.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/SDL2_image")
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/SDL2_image.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+    install(FILES "LICENSE.txt" DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/licenses/${PROJECT_NAME}")
+    if (NOT (WIN32 OR CYGWIN OR MINGW))
+        if(BUILD_SHARED_LIBS)
+            set(SOEXT ${CMAKE_SHARED_LIBRARY_SUFFIX}) # ".so", ".dylib", etc.
+            get_target_property(SONAME SDL2_image OUTPUT_NAME)
+            if(NOT ANDROID)
+                install(CODE "
+                    execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+                        \"lib${SONAME}${SOEXT}\" \"libSDL2_image${SOEXT}\"
+                        WORKING_DIRECTORY \"${PROJECT_BINARY_DIR}\")")
+                install(FILES ${PROJECT_BINARY_DIR}/libSDL2_image${SOEXT} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+            endif()
         endif()
     endif()
 endif()
@@ -709,7 +712,7 @@ if (BUILD_SAMPLES)
             target_link_libraries(${prog} PRIVATE mingw32)
             target_link_options(${prog} PRIVATE -mwindows)
         endif()
-        target_link_libraries(${prog} PRIVATE SDL2::image)
+        target_link_libraries(${prog} PRIVATE SDL2_image::SDL2_image)
         if (TARGET SDL2::SDL2main)
             target_link_libraries(${prog} PRIVATE SDL2::SDL2main)
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,12 @@ set(MICRO_VERSION 0)
 set(FULL_VERSION "${MAJOR_VERSION}.${MINOR_VERSION}.${MICRO_VERSION}")
 set(SDL_REQUIRED_VERSION 2.0.8)
 
+# Set defaults preventing destination file conflicts
+set(SDL_CMAKE_DEBUG_POSTFIX "d"
+    CACHE STRING "Name suffix for debug builds")
+
+mark_as_advanced(CMAKE_IMPORT_LIBRARY_SUFFIX SDL_CMAKE_DEBUG_POSTFIX)
+
 # Calculate a libtool-like version number
 math(EXPR BINARY_AGE "${MINOR_VERSION} * 100 + ${MICRO_VERSION}")
 math(EXPR SDL2_IMAGE_DEVELOPMENT "${MINOR_VERSION} % 2")
@@ -657,6 +663,10 @@ set_target_properties(SDL2_image PROPERTIES
     EXPORT_NAME ${sdl2_image_export_name}
     C_VISIBILITY_PRESET "hidden"
     )
+if (NOT ANDROID)
+    set_target_properties(SDL2_image PROPERTIES
+        DEBUG_POSTFIX "${SDL_CMAKE_DEBUG_POSTFIX}")
+endif()
 if (UNIX AND NOT APPLE AND NOT ANDROID)
     set_target_properties(SDL2_image PROPERTIES
         SOVERSION "${LT_MAJOR}"

--- a/SDL2_imageConfig.cmake.in
+++ b/SDL2_imageConfig.cmake.in
@@ -50,7 +50,29 @@ if(SDL2_IMAGE_SUPPORT_TIF AND NOT @SUPPORT_TIF_VENDORED@)
 endif()
 
 if(SDL2_IMAGE_SUPPORT_WEBP AND NOT @SUPPORT_WEBP_VENDORED@)
-	find_package(WebP REQUIRED)
+	if (NOT TARGET WebP::webp)
+		find_library(WEBP_LIBRARY NAMES webp)
+		if (NOT WEBP_LIBRARY)
+			message(FATAL_ERROR "Could not find webp library")
+		endif()
+		find_path(WEBP_INCLUDE NAMES webp/decode.h)
+		if (NOT WEBP_INCLUDE)
+			message(FATAL_ERROR "Could not find webp include directory")
+		endif()
+		add_library(webp UNKNOWN IMPORTED)
+		set_target_properties(webp PROPERTIES
+			IMPORTED_LOCATION "${WEBP_LIBRARY}"
+			INTERFACE_INCLUDE_DIRECTORIES "${WEBP_INCLUDE}"
+			)
+		list(APPEND PC_REQUIRES libwebp)
+		add_library(WebP::webp ALIAS webp)
+	endif()
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/SDL2_image-targets.cmake")
+if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL2_image-shared-targets.cmake")
+	include("${CMAKE_CURRENT_LIST_DIR}/SDL2_image-shared-targets.cmake")
+endif()
+
+if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL2_image-static-targets.cmake")
+	include("${CMAKE_CURRENT_LIST_DIR}/SDL2_image-static-targets.cmake")
+endif()


### PR DESCRIPTION
- Export a `SDL2_image::SDL2_image` target instead of a `SDL2::image` target
- Allow parallel installs of shared and static SLD2_Image:
  a `SDL2_image::SDL2_image` target for a shared build, and a `SDL2_image::SDL2_image-static` target for a static build

This allows the following:
```cmake
cmake_minimum_required(VERSION 3.10)
project(exampleproj)
find_package(SDL2 REQUIRED)
find_package(SDL2_image REQUIRED)

add_executable(showimage showimage.c)
target_link_libraries(showimage PRIVATE SDL2_image::SDL2_image SDL2::SDL2)

add_executable(showimage_static showimage.c)
target_link_libraries(showimage_static PRIVATE SDL2_image::SDL2_image-static SDL2::SDL2-static)
```

This is mostly useful for distributions who distribute both shared and static libraries.


A cmake install prefix might look like the following:

```
prefix
├── include
│   └── SDL2
│       └── SDL_image.h
├── lib64
│   ├── cmake
│   │   └── SDL2_image
│   │       ├── SDL2_imageConfig.cmake
│   │       ├── SDL2_image-shared-targets.cmake
│   │       ├── SDL2_image-shared-targets-debug.cmake
│   │       ├── SDL2_image-shared-targets-release.cmake
│   │       ├── SDL2_image-static-targets.cmake
│   │       ├── SDL2_image-static-targets-debug.cmake
│   │       └── SDL2_image-static-targets-release.cmake
│   ├── libSDL2_image-2.0d.so -> libSDL2_image-2.0d.so.0
│   ├── libSDL2_image-2.0d.so.0 -> libSDL2_image-2.0d.so.0.500.0
│   ├── libSDL2_image-2.0d.so.0.500.0
│   ├── libSDL2_image-2.0.so -> libSDL2_image-2.0.so.0
│   ├── libSDL2_image-2.0.so.0 -> libSDL2_image-2.0.so.0.500.0
│   ├── libSDL2_image-2.0.so.0.500.0
│   ├── libSDL2_image.a
│   ├── libSDL2_imaged.a
│   ├── libSDL2_image.so -> libSDL2_image-2.0.so
│   └── pkgconfig
│       └── SDL2_image.pc
└── share
    └── licenses
        └── SDL2_image
            └── LICENSE.txt
```