### PR TITLE
cmake: fixed the use of SDL_image with disabled BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ project(SDL2_image LANGUAGES C
 
 message(STATUS "Configuring ${PROJECT_NAME} ${PROJECT_VERSION}")
 
-if (NOT ANDROID AND NOT (TARGET SDL2::SDL2 OR TARGET SDL2::SDL2-static))
+if (NOT (TARGET SDL2::SDL2 OR TARGET SDL2::SDL2-static))
     find_package(SDL2 REQUIRED)
 endif()
 
@@ -205,7 +205,7 @@ endfunction()
 
 # Workaround for Ubuntu 20.04's SDL being older than
 # https://github.com/libsdl-org/SDL/issues/3531
-if (NOT TARGET SDL2::SDL2)
+if (NOT (TARGET SDL2::SDL2 OR TARGET SDL2::SDL2-static))
     find_library(SDL2_LIBRARY
         NAMES SDL2
         HINTS "${SDL2_EXEC_PREFIX}"


### PR DESCRIPTION
- Fixed using SDL_image as subproject with cmake's add_subdirectory with disabled BUILD_SHARED_LIBS
- Removed checks for ANDROID when detecting SDL2 or SDL2-static

From now we can use SDL_image with cmake in this way

```
option(BUILD_SHARED_LIBS "Build the library as a shared library" OFF)
option(BUILD_SAMPLES "Build the sample program(s)" OFF)
option(SDL_STATIC_PIC "Static version of the library should be built with Position Independent Code" ON)

add_subdirectory(external/SDL)
add_subdirectory(external/SDL_image )
add_subdirectory(path_to_your_project)
```