### PR TITLE
showimage: Restore automation-friendly behaviour of -quit

### DIFF
--- a/showimage.c
+++ b/showimage.c
@@ -56,6 +56,7 @@ int main(int argc, char *argv[])
     Uint32 flags;
     int i, w, h;
     int done = 0;
+    int quit = 0;
     SDL_Event event;
     const char *saveFile = NULL;
 
@@ -89,7 +90,8 @@ int main(int argc, char *argv[])
         }
 
         if ( SDL_strcmp(argv[i], "-quit") == 0 ) {
-            break;
+            quit = 1;
+            continue;
         }
 
         if ( SDL_strcmp(argv[i], "-save") == 0 && argv[i+1] ) {
@@ -132,7 +134,7 @@ int main(int argc, char *argv[])
         SDL_SetWindowSize(window, w, h);
         SDL_ShowWindow(window);
 
-        done = 0;
+        done = quit;
         while ( !done ) {
             while ( SDL_PollEvent(&event) ) {
                 switch (event.type) {


### PR DESCRIPTION
I added the -quit option for simple automated testing (with hindsight,
perhaps "-quit-after-loading" would have been a better name). The
intention was that something like

    showimage -quit -save out.bmp in.jpg -save out2.bmp in.png

would go through the motions of loading each image, save it to the
corresponding output file, but not actually wait for input or rendering.

---

I've started trying to learn the SDL_test framework well enough to add an automated test with better coverage, but that PR isn't ready yet, and probably shouldn't be considered a blocker for 2.5.1.