### PR TITLE
test: Set a timeout for unit tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,7 +50,9 @@ foreach(prog ${ALL_TESTS})
     )
     set_tests_properties(
         ${prog}
-        PROPERTIES ENVIRONMENT "${TESTS_ENVIRONMENT}"
+        PROPERTIES
+        ENVIRONMENT "${TESTS_ENVIRONMENT}"
+        TIMEOUT 30
     )
     if(INSTALL_TESTS)
         set(exe ${prog})


### PR DESCRIPTION
Suggested by @madebr on #245.

A 30 second timeout happens to be the default in Meson, but otherwise
this is completely arbitrary.

Under normal circumstances, our only test so far takes about 1 second,
so this gives us plenty of headroom for slower architectures or
additional test coverage in future.