### PR TITLE
workflows: Don't try to build tests on mingw + cmake

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,22 +91,26 @@ jobs:
     - name: Configure CMake
       if: "matrix.platform.cmake"
       run: |
-        cmake -B build \
+        set -- \
           -DBUILD_SHARED_LIBS=ON \
           -DCMAKE_BUILD_TYPE=Release \
           -DSDL2IMAGE_DEPS_SHARED=OFF \
           -DSDL2IMAGE_SAMPLES=ON \
-          -DSDL2IMAGE_TESTS=ON \
-          -DSDL2IMAGE_TESTS_INSTALL=ON \
           -DSDL2IMAGE_JXL=ON \
           -DSDL2IMAGE_TIF=ON \
           -DSDL2IMAGE_WEBP=ON \
           ${{ matrix.platform.cmake }}
+        # mingw-w64-*-SDL2 doesn't have SDL_test, so only build this on Unix
+        if [ "${{ matrix.platform.shell }}" = 'sh' ]; then
+          set -- "$@" -DSDL2IMAGE_TESTS=ON
+          set -- "$@" -DSDL2IMAGE_TESTS_INSTALL=ON
+        fi
+        cmake -B build "$@"
     - name: Build
       if: "matrix.platform.cmake"
       run: cmake --build build/ --config Release --verbose
     - name: Run build-time tests
-      if: "matrix.platform.cmake"
+      if: "matrix.platform.shell == 'sh' && matrix.platform.cmake"
       run: |
         set -eu
 


### PR DESCRIPTION
The mingw-w64-*-SDL2 packages don't contain the SDL_test library,
so skip the tests on Windows, like we already did for Autotools.

---

This should hopefully fix the mingw64+cmake build.