### PR TITLE
Revert CI regressions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
         parallel="$(getconf _NPROCESSORS_ONLN)"
         make -j"${parallel}" -C build-autotools V=1
     - name: Run tests with Autotools
-      if: "! matrix.platform.cmake"
+      if: "runner.os == 'Linux' && ! matrix.platform.cmake"
       run: |
         set -eu
         parallel="$(getconf _NPROCESSORS_ONLN)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
             cmake: '-DSDL2IMAGE_BACKEND_STB=OFF -DSDL2IMAGE_BACKEND_WIC=OFF -DSDL2IMAGE_VENDORED=OFF -DSDL2IMAGE_AVIF=ON -G "Ninja Multi-Config"' }
         - { name: Linux (autotools),            os: ubuntu-20.04,   shell: sh }
         - { name: Linux (CMake),                os: ubuntu-20.04,   shell: sh,   cmake: '-DSDL2IMAGE_VENDORED=ON -GNinja' }
-        - { name: Linux (CMake, static),        os: ubuntu-20.04,   shell: sh,   cmake: '-DSDL2IMAGE_VENDORED=ON -DBUILD_SHARED_LIBS=OFF -GNinja' }
+        - { name: 'Linux (CMake, static)',      os: ubuntu-20.04,   shell: sh,   cmake: '-DSDL2IMAGE_VENDORED=ON -DBUILD_SHARED_LIBS=OFF -GNinja' }
         - { name: Macos (autotools),            os: macos-latest,   shell: sh }
         - { name: Macos (CMake),                os: macos-latest,   shell: sh,   cmake: '-DSDL2IMAGE_VENDORED=ON -GNinja' }
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,10 +94,7 @@ jobs:
         cmake -B build \
           -DBUILD_SHARED_LIBS=ON \
           -DCMAKE_BUILD_TYPE=Release \
-          -DSDL2IMAGE_DEPS_SHARED=OFF \
           -DSDL2IMAGE_SAMPLES=ON \
-          -DSDL2IMAGE_TESTS=ON \
-          -DSDL2IMAGE_TESTS_INSTALL=ON \
           -DSDL2IMAGE_JXL=ON \
           -DSDL2IMAGE_TIF=ON \
           -DSDL2IMAGE_WEBP=ON \
@@ -105,34 +102,6 @@ jobs:
     - name: Build
       if: "matrix.platform.cmake"
       run: cmake --build build/ --config Release --verbose
-    - name: Run build-time tests
-      if: "matrix.platform.cmake"
-      run: |
-        set -eu
-
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_AVIF=0
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_BMP=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_CUR=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_GIF=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_ICO=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_JPG=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_JXL=0
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_LBM=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_PCX=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_PNG=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_PNM=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_QOI=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_SVG=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_TGA=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_TIF=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_WEBP=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_XPM=1
-        export SDL_IMAGE_TEST_REQUIRE_LOAD_XV=1
-
-        export SDL_IMAGE_TEST_REQUIRE_SAVE_JPG=1
-        export SDL_IMAGE_TEST_REQUIRE_SAVE_PNG=1
-
-        ctest -VV --test-dir build/test
     - name: Install
       if: "matrix.platform.shell == 'sh' && matrix.platform.cmake"
       run: |
@@ -140,16 +109,6 @@ jobs:
         rm -fr DESTDIR-cmake
         DESTDIR=$(pwd)/DESTDIR-cmake cmake --install build/ --config Release
         find DESTDIR-cmake | LC_ALL=C sort -u
-    - name: Upload artifacts
-      if: "failure() && matrix.platform.shell == 'sh' && matrix.platform.cmake"
-      uses: actions/upload-artifact@v3
-      with:
-        name: "${{ matrix.platform.name }} artifacts"
-        path: |
-          build/test/*.bmp
-          build/test/*.jpg
-          build/test/*.png
-        if-no-files-found: ignore
 
     - name: Configure Autotools
       if: "! matrix.platform.cmake"

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -64,7 +64,8 @@ generatetestmeta:
 
 install-data-hook: installtestmeta
 installtestmeta: generatetestmeta
-	install -m644 -D -t $(DESTDIR)$(testmetadir) *.test
+	install -d $(DESTDIR)$(testmetadir)
+	install -m644 *.test $(DESTDIR)$(testmetadir)
 
 clean-local:
 	rm -f *.test


### PR DESCRIPTION
* Fix name of Linux static build job

* Revert "workflows: Run the automated test for CMake builds"
    
    This reverts commit 72d9524536a34273210fab434d1c14f212ffd937.
    Building in this mode is failing; let's get the CI green again before
    fixing this.

* workflows: Disable automated test on macOS for now
    
    Various test failures are under investigation (see #248).