### PR TITLE
test: Distribute template.test.in in source release tarballs

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -20,7 +20,7 @@ AM_TESTS_ENVIRONMENT = \
 	$(NULL)
 
 EXTRA_DIST = \
-	CMakeLists.txt Makefile.os2
+	CMakeLists.txt Makefile.os2 template.test.in
 
 if INSTALL_TESTS
 testexec_PROGRAMS = $(test_programs)

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -566,7 +566,7 @@ AM_TESTS_ENVIRONMENT = \
 	$(NULL)
 
 EXTRA_DIST = \
-	CMakeLists.txt Makefile.os2
+	CMakeLists.txt Makefile.os2 template.test.in
 
 @INSTALL_TESTS_TRUE@dist_testexec_DATA = \
 @INSTALL_TESTS_TRUE@	palette.bmp \


### PR DESCRIPTION
We'll need this if we want to build with --enable-installed-tests
from an official source release, which I'd like to do in Debian.