### PR TITLE
Use specific CMake version on github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - { name: Windows (MSVC+CMake),         os: windows-latest, shell: sh,   cmake: '-DSDL2IMAGE_VENDORED=ON -G "Ninja Multi-Config"', msvc: 1 }
+        - { name: Windows (MSVC+CMake),         os: windows-latest, shell: sh,   cmake: '-DSDL2IMAGE_VENDORED=ON -GNinja', msvc: 1 }
         - { name: Windows (mingw32+autotools),  os: windows-latest, shell: 'msys2 {0}', msystem: mingw32, msys-env: mingw-w64-i686 }
         - { name: Windows (mingw64+CMake),      os: windows-latest, shell: 'msys2 {0}', msystem: mingw64, msys-env: mingw-w64-x86_64,
             cmake: '-DSDL2IMAGE_BACKEND_STB=OFF -DSDL2IMAGE_BACKEND_WIC=OFF -DSDL2IMAGE_VENDORED=OFF -DSDL2IMAGE_AVIF=ON -G "Ninja Multi-Config"' }
@@ -106,6 +106,11 @@ jobs:
       if: "runner.os == 'Linux' && matrix.platform.cmake"
       run: ./test-versioning.sh
 
+    - name: Setup CMake
+      if: ${{ matrix.platform.cmake && !matrix.platform.msystem && !matrix.platform.msvc }}
+      uses: jwlawson/actions-setup-cmake@v1.12
+      with:
+        cmake-version: '3.16'
     - name: Configure CMake
       if: "matrix.platform.cmake"
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
@@ -704,8 +704,10 @@ if(SDL2IMAGE_INSTALL)
         endif()
         # Only install a SDL2_image.pc file in Release mode
         install(CODE "
-            file(COPY_FILE \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_image-$<CONFIG>.pc\"
-                \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_image.pc\" ONLY_IF_DIFFERENT)
+            # FIXME: use file(COPY_FILE) if minimum CMake version >= 3.21
+            execute_process(COMMAND \"\${CMAKE_COMMAND}\" -E copy_if_different
+                \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_image-$<CONFIG>.pc\"
+                \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_image.pc\")
             file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${PC_DESTDIR}\"
                 TYPE FILE
                 FILES \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_image.pc\")" CONFIG Release COMPONENT devel)
@@ -733,7 +735,7 @@ if(SDL2IMAGE_SAMPLES)
     find_package(SDL2main)
 
     foreach(prog showanim showimage)
-        # FIXME: mingw should be handles by SDL2::SDL2(-static) target
+        # FIXME: mingw should be handled by SDL2::SDL2(-static) target
         if(MINGW)
             target_link_libraries(${prog} PRIVATE mingw32)
             target_link_options(${prog} PRIVATE -mwindows)

--- a/cmake/FindPrivateSDL2.cmake
+++ b/cmake/FindPrivateSDL2.cmake
@@ -3,9 +3,6 @@
 include(FindPackageHandleStandardArgs)
 include("${CMAKE_CURRENT_LIST_DIR}/CommonFindSDL2.cmake")
 
-message("_lib_suffixes: ${_lib_suffixes}")
-message("_inc_suffixes: ${_inc_suffixes}")
-
 find_library(SDL2_LIBRARY
     NAMES SDL2
     HINTS ${SDL2_DIR} ENV SDL2_DIR


### PR DESCRIPTION
The reasoning behind this extra github workflow dependency is enforcing compatibility with the minimum required cmake version we declared at the top of the cmake build script.