### PR TITLE
Fix some formats on big-endian machines

### DIFF
--- a/IMG_jpg.c
+++ b/IMG_jpg.c
@@ -492,11 +492,9 @@ static void jpeg_SDL_RW_dest(j_compress_ptr cinfo, SDL_RWops *ctx)
 
 static int IMG_SaveJPG_RW_jpeglib(SDL_Surface *surface, SDL_RWops *dst, int freedst, int quality)
 {
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+    /* The JPEG library reads bytes in R,G,B order, so this is the right
+     * encoding for either endianness */
     static const Uint32 jpg_format = SDL_PIXELFORMAT_RGB24;
-#else
-    static const Uint32 jpg_format = SDL_PIXELFORMAT_BGR24;
-#endif
     struct jpeg_compress_struct cinfo;
     struct my_error_mgr jerr;
     JSAMPROW row_pointer[1];
@@ -703,11 +701,9 @@ static void IMG_SaveJPG_RW_tinyjpeg_callback(void* context, void* data, int size
 
 static int IMG_SaveJPG_RW_tinyjpeg(SDL_Surface *surface, SDL_RWops *dst, int freedst, int quality)
 {
-#if SDL_BYTEORDER == SDL_LIL_ENDIAN
+    /* The JPEG library reads bytes in R,G,B order, so this is the right
+     * encoding for either endianness */
     static const Uint32 jpg_format = SDL_PIXELFORMAT_RGB24;
-#else
-    static const Uint32 jpg_format = SDL_PIXELFORMAT_BGR24;
-#endif
     SDL_Surface* jpeg_surface = surface;
     int result = -1;
 

--- a/IMG_qoi.c
+++ b/IMG_qoi.c
@@ -81,20 +81,19 @@ SDL_Surface *IMG_LoadQOI_RW(SDL_RWops *src)
     }
 
     pixel_data = qoi_decode(data, (int)size, &image_info, 4);
+    /* pixel_data is in R,G,B,A order regardless of endianness */
     SDL_free(data);
     if ( !pixel_data ) {
         IMG_SetError("Couldn't parse QOI image");
         return NULL;
     }
 
-    surface = SDL_CreateRGBSurface(SDL_SWSURFACE,
-                                   image_info.width,
-                                   image_info.height,
-                                   32,
-                                   0x000000FF,
-                                   0x0000FF00,
-                                   0x00FF0000,
-                                   0xFF000000);
+    surface = SDL_CreateRGBSurfaceWithFormat(0,
+                                             image_info.width,
+                                             image_info.height,
+                                             32,
+                                             SDL_PIXELFORMAT_RGBA32);
+
     if ( !surface ) {
         SDL_free(pixel_data);
         IMG_SetError("Couldn't create SDL_Surface");

--- a/IMG_svg.c
+++ b/IMG_svg.c
@@ -137,14 +137,12 @@ SDL_Surface *IMG_LoadSizedSVG_RW(SDL_RWops *src, int width, int height)
         scale = 1.0f;
     }
 
-    surface = SDL_CreateRGBSurface(SDL_SWSURFACE,
-                                   (int)SDL_ceilf(image->width * scale),
-                                   (int)SDL_ceilf(image->height * scale),
-                                   32,
-                                   0x000000FF,
-                                   0x0000FF00,
-                                   0x00FF0000,
-                                   0xFF000000);
+    surface = SDL_CreateRGBSurfaceWithFormat(0,
+                                             (int)SDL_ceilf(image->width * scale),
+                                             (int)SDL_ceilf(image->height * scale),
+                                             32,
+                                             SDL_PIXELFORMAT_RGBA32);
+
     if (!surface) {
         nsvgDeleteRasterizer(rasterizer);
         nsvgDelete(image);

--- a/tiny_jpeg.h
+++ b/tiny_jpeg.h
@@ -385,12 +385,17 @@ static const uint8_t tjei_zig_zag[64] =
     35, 36, 48, 49, 57, 58, 62, 63,
 };
 
-// Memory order as big endian. 0xhilo -> 0xlohi which looks as 0xhilo in memory.
-static uint16_t tjei_be_word(const uint16_t le_word)
+// Memory order as big endian.
+// On little-endian machines: 0xhilo -> 0xlohi which looks as 0xhi 0xlo in memory
+// On big-endian machines: leave 0xhilo unchanged
+static uint16_t tjei_be_word(const uint16_t native_word)
 {
-    uint16_t lo = (le_word & 0x00ff);
-    uint16_t hi = ((le_word & 0xff00) >> 8);
-    return (uint16_t)((lo << 8) | hi);
+    uint8_t bytes[2];
+    uint16_t result;
+    bytes[1] = (native_word & 0x00ff);
+    bytes[0] = ((native_word & 0xff00) >> 8);
+    memcpy(&result, bytes, sizeof(bytes));
+    return result;
 }
 
 // ============================================================


### PR DESCRIPTION
* jpg: Fix channel order of saved JPEGs on big-endian platforms
    
    Both of the JPEG libraries we use (jpeglib or tinyjpeg) expect to see
    the red channel in the first byte of the buffer, regardless of whether
    the first byte is considered to be the most-significant or
    least-significant in native endianness.

* tiny_jpeg: Don't byteswap 16-bit words if already big-endian
    
    Previously, this assumed that native endianness was always little-endian,
    which is true for x86 and most other architectures, but untrue for
    some (mostly older) unusual architectures.
    
    Forwarded: https://github.com/serge-rgb/TinyJPEG/pull/16

* qoi: Fix channel order on big-endian platforms
    
    qoi.h always decodes the red channel of the first pixel into the first
    byte of the buffer, regardless of whether interpreting the buffer as
    a sequence of 32-bit words would consider that to be the most or least
    significant byte of the first word. In SDL terminology that's
    SDL_PIXELFORMAT_RGBA32.

* svg: Fix channel order on big-endian platforms
    
    nanosvg always decodes the red channel of the first pixel into the first
    byte of the buffer, regardless of whether interpreting the buffer as
    a sequence of 32-bit words would consider that to be the most or least
    significant byte of the first word. In SDL terminology that's
    SDL_PIXELFORMAT_RGBA32.