### PR TITLE
test: Add PCX and TGA samples to list of test data

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,9 +12,11 @@ set(RESOURCE_FILES
     sample.ico
     sample.jpg
     sample.jxl
+    sample.pcx
     sample.png
     sample.pnm
     sample.qoi
+    sample.tga
     sample.tif
     sample.webp
     sample.xcf

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -40,9 +40,11 @@ dist_testexec_DATA = \
 	sample.ico \
 	sample.jpg \
 	sample.jxl \
+	sample.pcx \
 	sample.png \
 	sample.pnm \
 	sample.qoi \
+	sample.tga \
 	sample.tif \
 	sample.webp \
 	sample.xcf \


### PR DESCRIPTION
Fixes: b1f650d "Added PCX and TGA sample files for testing"