### PR TITLE
nanosvg: sync with mainstream:

### DIFF
--- a/IMG_svg.c
+++ b/IMG_svg.c
@@ -27,6 +27,10 @@
 
 #ifdef LOAD_SVG
 
+static float SDLCALL SDLIMAGE_roundf(float x) {
+    return (x >= 0.0f) ? SDL_floorf(x + 0.5f) : SDL_ceilf(x - 0.5f);
+}
+
 /* Replace C runtime functions with SDL C runtime functions for building on Windows */
 #define free    SDL_free
 #define malloc  SDL_malloc
@@ -63,6 +67,7 @@
 #define sqrt    SDL_sqrt
 #define sqrtf   SDL_sqrtf
 #define tanf    SDL_tanf
+#define roundf  SDLIMAGE_roundf
 #ifndef FLT_MAX
 #define FLT_MAX     3.402823466e+38F
 #endif

--- a/nanosvgrast.h
+++ b/nanosvgrast.h
@@ -76,8 +76,6 @@ NSVG_EXPORT void nsvgDeleteRasterizer(NSVGrasterizer*);
 #endif
 #endif
 
-#endif // NANOSVGRAST_H
-
 #ifdef NANOSVGRAST_IMPLEMENTATION
 
 /*
@@ -1463,3 +1461,5 @@ NSVG_EXPORT void nsvgRasterize(NSVGrasterizer* r,
 }
 
 #endif
+
+#endif // NANOSVGRAST_H


### PR DESCRIPTION
This imports the following four commits from mainstream nanosvg:
https://github.com/memononen/nanosvg/commit/3cdd4a9d788695699799b37d492e45e2c3625790
https://github.com/memononen/nanosvg/commit/ccdb1995134d340a93fb20e3a3d323ccb3838dd0
https://github.com/memononen/nanosvg/commit/214cf85efcdc67524335ad0e2a2d5982246b6a72
https://github.com/memononen/nanosvg/commit/3bcdf2f3cdc1bf9197c2dce81368bfc6f99205a7

This adds roundf() as a new dependency: Since SDL_roundf() requires
SDL >= 2.0.16, invented a tiny local `SDLIMAGE_roundf()` function for
it instead.