### PR TITLE
Fix memory leak in qoi decoder

### DIFF
--- a/IMG_qoi.c
+++ b/IMG_qoi.c
@@ -101,6 +101,7 @@ SDL_Surface *IMG_LoadQOI_RW(SDL_RWops *src)
     }
 
     SDL_memcpy(surface->pixels, pixel_data, image_info.width*image_info.height*4);
+    SDL_free(pixel_data);
 
     return surface;
 }


### PR DESCRIPTION
Fix memory leak in qoi decoder.
SDL_memcpy copies the data, it does not
move the pointer, so free it after use
just like it is done if surface creation
fails.