### PR TITLE
cmake: Fix static linking to dependencies with "-" in library name

### DIFF
--- a/sdl2_image-config.cmake.in
+++ b/sdl2_image-config.cmake.in
@@ -48,7 +48,7 @@ set(_sdl2image_libdir   "${libdir}")
 set(_sdl2image_incdir   "${includedir}/SDL2")
 
 # Convert _sdl2image_extra_static_libraries to list and keep only libraries
-string(REGEX MATCHALL "(-[lm]([a-zA-Z0-9._]+))|(-Wl,[^ ]*framework[^ ]*)" _sdl2image_extra_static_libraries "${_sdl2image_extra_static_libraries}")
+string(REGEX MATCHALL "(-[lm]([-a-zA-Z0-9._]+))|(-Wl,[^ ]*framework[^ ]*)" _sdl2image_extra_static_libraries "${_sdl2image_extra_static_libraries}")
 string(REGEX REPLACE "^-l" "" _sdl2image_extra_static_libraries "${_sdl2image_extra_static_libraries}")
 string(REGEX REPLACE ";-l" ";" _sdl2image_extra_static_libraries "${_sdl2image_extra_static_libraries}")
 


### PR DESCRIPTION
If we gain a dependency on a library with "-" in its name, we'd parse
the list of dependencies incorrectly; fix that. Equivalent to
https://github.com/libsdl-org/SDL/pull/5789 in SDL.