### PR TITLE
More consistent RGB PNG saving with LIBPNG

### DIFF
--- a/IMG_png.c
+++ b/IMG_png.c
@@ -629,9 +629,18 @@ static int IMG_SavePNG_RW_libpng(SDL_Surface *surface, SDL_RWops *dst, int freed
             }
         }
         else if (surface->format->format == SDL_PIXELFORMAT_RGB24) {
+            /* If the surface is exactly the right RGB format it is just passed through */
             png_color_type = PNG_COLOR_TYPE_RGB;
         }
+        else if (!SDL_ISPIXELFORMAT_ALPHA(surface->format->format)) {
+            /* If the surface is not exactly the right RGB format but does not have alpha
+               information, it should be converted to RGB24 before being passed through */
+            png_color_type = PNG_COLOR_TYPE_RGB;
+            source = SDL_ConvertSurfaceFormat(surface, SDL_PIXELFORMAT_RGB24, 0);
+        }
         else if (surface->format->format != png_format) {
+            /* Otherwise, (surface has alpha data), and it is not in the exact right
+               format , so it should be converted to that */
             source = SDL_ConvertSurfaceFormat(surface, png_format, 0);
         }
 


### PR DESCRIPTION
For #282.

Sometime between SDL 2.0.5 and today, RGB24 PNG saving support was added. (See the relevant code section in 2.0.5: https://github.com/libsdl-org/SDL_image/blob/release-2.0.5/IMG_png.c#L570-L591, versus now: https://github.com/libsdl-org/SDL_image/blob/prerelease-2.5.2/IMG_png.c#L631-L633)

But it only checks if the surface is exactly RGB24. If the surface is BGR24, or any other format that doesn't have an alpha channel, it is converted to RGBA32 anyways.

This patch makes the behavior more consistent, because BGR24 or RGB24 are both saved as RGB PNGs (as opposed to RGBA PNGs or Paletted PNGs).