### PR TITLE
Minor typo fixes

### DIFF
--- a/IMG_gif.c
+++ b/IMG_gif.c
@@ -277,7 +277,7 @@ IMG_LoadGIF_RW_Internal(SDL_RWops *src, SDL_bool load_anim)
         }
         if (c == '!') {     /* Extension */
             if (!ReadOK(src, &c, 1)) {
-                RWSetMsg("EOF / read error on extention function code");
+                RWSetMsg("EOF / read error on extension function code");
                 goto done;
             }
             DoExtension(src, c, state);
@@ -559,7 +559,7 @@ LWZReadByte(SDL_RWops *src, int flag, int input_code_size, State_t * state)
 
             if (count != 0) {
             /*
-             * pm_message("missing EOD in data stream (common occurence)");
+             * pm_message("missing EOD in data stream (common occurrence)");
              */
             }
             return -2;

--- a/IMG_lbm.c
+++ b/IMG_lbm.c
@@ -224,7 +224,7 @@ SDL_Surface *IMG_LoadLBM_RW( SDL_RWops *src )
         }
     }
 
-    /* compute some usefull values, based on the bitmap header */
+    /* compute some useful values, based on the bitmap header */
 
     width = ( bmhd.w + 15 ) & 0xFFFFFFF0;  /* Width in pixels modulo 16 */
 
@@ -256,7 +256,7 @@ SDL_Surface *IMG_LoadLBM_RW( SDL_RWops *src )
     if ( bmhd.mask & 2 )               /* There is a transparent color */
         SDL_SetColorKey( Image, SDL_TRUE, bmhd.tcolor );
 
-    /* Update palette informations */
+    /* Update palette information */
 
     /* There is no palette in 24 bits ILBM file */
     if ( nbcolors>0 && flagHAM==0 )

--- a/cmake/test/CMakeLists.txt
+++ b/cmake/test/CMakeLists.txt
@@ -13,7 +13,7 @@ include(FeatureSummary)
 option(TEST_SHARED "Test linking to shared SDL2_image library" ON)
 add_feature_info("TEST_SHARED" TEST_SHARED "Test linking with shared library")
 
-option(TEST_STATIC "Test linking to static SDL2_image libary" ON)
+option(TEST_STATIC "Test linking to static SDL2_image library" ON)
 add_feature_info("TEST_STATIC" TEST_STATIC "Test linking with static library")
 
 if(TEST_SHARED)


### PR DESCRIPTION
From another project I learned about a tool called codespell that helps you find typos in source code. https://pypi.org/project/codespell/.

I found a few and fixed a few. I'm surprised there weren't more actionable ones.