### PR TITLE
autotools: relax soname pattern for dynamic loading

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -284,8 +284,8 @@ DIST_SUBDIRS = . test
 am__DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/SDL2_image.pc.in \
 	$(srcdir)/SDL2_image.spec.in \
 	$(srcdir)/sdl2_image-config-version.cmake.in \
-	$(srcdir)/sdl2_image-config.cmake.in ar-lib compile \
-	config.guess config.sub depcomp install-sh ltmain.sh missing
+	$(srcdir)/sdl2_image-config.cmake.in compile config.guess \
+	config.sub depcomp install-sh ltmain.sh missing
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
 distdir = $(PACKAGE)-$(VERSION)
 top_distdir = $(distdir)

--- a/configure
+++ b/configure
@@ -13340,6 +13340,57 @@ printf "%s\n" "no" >&6; }
 		PKG_CONFIG=""
 	fi
 fi
+for ac_prog in gawk mawk nawk awk
+do
+  # Extract the first word of "$ac_prog", so it can be a program name with args.
+set dummy $ac_prog; ac_word=$2
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_AWK+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  if test -n "$AWK"; then
+  ac_cv_prog_AWK="$AWK" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_AWK="$ac_prog"
+    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+fi
+fi
+AWK=$ac_cv_prog_AWK
+if test -n "$AWK"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $AWK" >&5
+printf "%s\n" "$AWK" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+
+
+  test -n "$AWK" && break
+done
+
+
+if test -z "$AWK"; then
+    as_fn_error $? "*** Required awk tool not found!" "$LINENO" 5
+fi
 
 case "$host" in
     *-*-beos*)
@@ -13426,7 +13477,7 @@ find_lib()
         host_lib_path="$ac_default_prefix/$base_libdir $ac_default_prefix/$base_bindir /usr/$base_libdir /usr/local/$base_libdir"
     fi
     for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
-        lib=`ls -- $path/$1 2>/dev/null | sed -e '/\.so\..*\./d' -e 's,.*/,,' | sort | tail -1`
+        lib=`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed 's/^[0-9]\+ //'`
         if test x$lib != x; then
             echo $lib
             return

--- a/configure
+++ b/configure
@@ -13477,7 +13477,7 @@ find_lib()
         host_lib_path="$ac_default_prefix/$base_libdir $ac_default_prefix/$base_bindir /usr/$base_libdir /usr/local/$base_libdir"
     fi
     for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
-        lib=`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed 's/^[0-9]\+ //'`
+        lib=`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed -e 's/^[0-9]\+ //'`
         if test x$lib != x; then
             echo $lib
             return

--- a/configure
+++ b/configure
@@ -13477,7 +13477,7 @@ find_lib()
         host_lib_path="$ac_default_prefix/$base_libdir $ac_default_prefix/$base_bindir /usr/$base_libdir /usr/local/$base_libdir"
     fi
     for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
-        lib=`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed -e 's/^[0-9]\+ //'`
+        lib=`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed -e 's/^[0-9]+ //'`
         if test "x$lib" != x; then
             echo $lib
             return

--- a/configure
+++ b/configure
@@ -13477,8 +13477,8 @@ find_lib()
         host_lib_path="$ac_default_prefix/$base_libdir $ac_default_prefix/$base_bindir /usr/$base_libdir /usr/local/$base_libdir"
     fi
     for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
-        lib=`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed -e 's/^[0-9]+ //'`
-        if test "x$lib" != x; then
+        lib=`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | $AWK '{print $2;}'`
+        if test x$lib != x; then
             echo $lib
             return
         fi

--- a/configure
+++ b/configure
@@ -13478,7 +13478,7 @@ find_lib()
     fi
     for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
         lib=`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed -e 's/^[0-9]\+ //'`
-        if test x$lib != x; then
+        if test "x$lib" != x; then
             echo $lib
             return
         fi

--- a/configure.ac
+++ b/configure.ac
@@ -137,8 +137,8 @@ find_lib()
         host_lib_path="$ac_default_prefix/$base_libdir $ac_default_prefix/$base_bindir /usr/$base_libdir /usr/local/$base_libdir"
     fi
     for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
-        lib=[`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed -e 's/^[0-9]\+ //'`]
-        if test "x$lib" != x; then
+        lib=[`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed -e 's/^[0-9]+ //'`]
+        if test x$lib != x; then
             echo $lib
             return
         fi

--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,7 @@ find_lib()
         host_lib_path="$ac_default_prefix/$base_libdir $ac_default_prefix/$base_bindir /usr/$base_libdir /usr/local/$base_libdir"
     fi
     for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
-        lib=[`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed -e 's/^[0-9]+ //'`]
+        lib=[`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | $AWK '{print $2;}'`]
         if test x$lib != x; then
             echo $lib
             return

--- a/configure.ac
+++ b/configure.ac
@@ -138,7 +138,7 @@ find_lib()
     fi
     for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
         lib=[`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed -e 's/^[0-9]\+ //'`]
-        if test x$lib != x; then
+        if test "x$lib" != x; then
             echo $lib
             return
         fi

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,11 @@ AC_CHECK_TOOL(RC,[windres],[:])
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 PKG_PROG_PKG_CONFIG
+AC_PROG_AWK
+
+if test -z "$AWK"; then
+    AC_MSG_ERROR([*** Required awk tool not found!])
+fi
 
 case "$host" in
     *-*-beos*)
@@ -132,7 +137,7 @@ find_lib()
         host_lib_path="$ac_default_prefix/$base_libdir $ac_default_prefix/$base_bindir /usr/$base_libdir /usr/local/$base_libdir"
     fi
     for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
-        lib=[`ls -- $path/$1 2>/dev/null | sed -e '/\.so\..*\./d' -e 's,.*/,,' | sort | tail -1`]
+        lib=[`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed 's/^[0-9]\+ //'`]
         if test x$lib != x; then
             echo $lib
             return

--- a/configure.ac
+++ b/configure.ac
@@ -137,7 +137,7 @@ find_lib()
         host_lib_path="$ac_default_prefix/$base_libdir $ac_default_prefix/$base_bindir /usr/$base_libdir /usr/local/$base_libdir"
     fi
     for path in $env_lib_path $gcc_bin_path $gcc_lib_path $host_lib_path; do
-        lib=[`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed 's/^[0-9]\+ //'`]
+        lib=[`ls -- $path/$1 2>/dev/null | sed -e 's,.*/,,' | $AWK '{print length() " " $0;}' | sort -n -r | tail -1 | sed -e 's/^[0-9]\+ //'`]
         if test x$lib != x; then
             echo $lib
             return


### PR DESCRIPTION
SDL makes assumption that each dynamically loaded library must have
SONAME matching pattern <libname>.so.<digit>+ hence it discards any file
that has two (or more) digits after ".so". in practice however SONAME
might be in the form of ie <libname>.so.<major>.<minor>.

as a solution keep requirement for dynamically loaded files to be named
<libname>.so.* but consider all the possibilities and prefer the shortest
one.

Fixes: #289
From: libsdl-org/SDL#5901