### PR TITLE
fix linking options of Xcode's static library target

### DIFF
--- a/Xcode/SDL_image.xcodeproj/project.pbxproj
+++ b/Xcode/SDL_image.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		007288A80F0DA79800C302A9 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 007288A60F0DA79800C302A9 /* ApplicationServices.framework */; };
+		007288A80F0DA79800C302A9 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 007288A60F0DA79800C302A9 /* ApplicationServices.framework */; platformFilters = (macos, ); };
 		6313BF532785566D00F268AD /* IMG_qoi.c in Sources */ = {isa = PBXBuildFile; fileRef = 6313BF522785566D00F268AD /* IMG_qoi.c */; };
 		6313BF542785566D00F268AD /* IMG_qoi.c in Sources */ = {isa = PBXBuildFile; fileRef = 6313BF522785566D00F268AD /* IMG_qoi.c */; };
 		AA23FC7D20A2A1B90017DFB9 /* IMG_svg.c in Sources */ = {isa = PBXBuildFile; fileRef = AA50AA461F9C7C50003B9C0C /* IMG_svg.c */; };


### PR DESCRIPTION
Currently it's impossible to build static library target from command line with `xcodebuild` because of error:

> ApplicationServices is not available when building for iOS. (in target 'Static Library' from project 'SDL_image')

This PR fixes that by marking ApplicationServices framework as macOS-only (same as in the framework target).

However, it's interesting that with Xcode GUI it's possible to build for device (when you select "any iOS device" as destination) without any modifications. I tried to pass the `-destination` option to `xcodebuild`, but that didn't help. Maybe Xcode uses some undocumented variable to control this behaviour. Here's my build script: https://github.com/kambala-decapitator/vcmi-ios-depends/blob/e8528fe3ca3e3865d85718adc02acbf47209ecb3/build_depends.sh#L154