### PR TITLE
Fix wrong size malloc and minor memleak

### DIFF
--- a/IMG_png.c
+++ b/IMG_png.c
@@ -603,7 +603,7 @@ static int IMG_SavePNG_RW_libpng(SDL_Surface *surface, SDL_RWops *dst, int freed
             int i;
             int last_transparent = -1;
 
-            color_ptr = (png_colorp)SDL_malloc(sizeof(png_colorp) * ncolors);
+            color_ptr = (png_colorp)SDL_malloc(sizeof(png_color) * ncolors);
             if (color_ptr == NULL)
             {
                 lib.png_destroy_write_struct(&png_ptr, &info_ptr);
@@ -656,6 +656,7 @@ static int IMG_SavePNG_RW_libpng(SDL_Surface *surface, SDL_RWops *dst, int freed
 
             row_pointers = (png_bytep *) SDL_malloc(sizeof(png_bytep) * source->h);
             if (!row_pointers) {
+                free(color_ptr);
                 lib.png_destroy_write_struct(&png_ptr, &info_ptr);
                 IMG_SetError("Out of memory");
                 return -1;

--- a/IMG_png.c
+++ b/IMG_png.c
@@ -656,7 +656,7 @@ static int IMG_SavePNG_RW_libpng(SDL_Surface *surface, SDL_RWops *dst, int freed
 
             row_pointers = (png_bytep *) SDL_malloc(sizeof(png_bytep) * source->h);
             if (!row_pointers) {
-                free(color_ptr);
+                SDL_free(color_ptr);
                 lib.png_destroy_write_struct(&png_ptr, &info_ptr);
                 IMG_SetError("Out of memory");
                 return -1;


### PR DESCRIPTION
This is a quickfix PR for two warnings reported by clang.

The first issue is `sizeof(png_colorp)` should really be `sizeof(png_color)` (because `png_colorp` is a pointer type)... Fortunately `sizeof(png_colorp)` is 4 or 8 depending on the platform and `sizeof(png_color)` is a 3 so this code was only mallocing more space than needed and not less. But now I fixed it to malloc the exact size.

Second issue was that `color_ptr` was being leaked in an early-exit-on-error case
