### PR TITLE
Don't use sdl2 --HEAD on Apple CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
             webp \
             zlib \
             ${NULL+}
-          brew install sdl2 --HEAD
+          brew install sdl2
     - name: Setup Linux dependencies
       if: runner.os == 'Linux'
       run: |


### PR DESCRIPTION
Homebrew provides SDL2 2.24.1, so use the prebuilt binary

Closes #299