### PR TITLE
Fix loading of 4-bit .ico files

### DIFF
--- a/IMG_bmp.c
+++ b/IMG_bmp.c
@@ -240,7 +240,6 @@ LoadICOCUR_RW(SDL_RWops * src, int type, int freesrc)
         case 1:
         case 4:
             ExpandBMP = biBitCount;
-            biBitCount = 8;
             break;
         case 8:
             ExpandBMP = 8;


### PR DESCRIPTION
`biBitCount` is used on line 761 to infer the default palette size if `biClrUsed` is zero, but is set to 8 here for no apparent reason. Of course a 16-color image doesn't have a 256-color palette. It seems the bug has existed forever.

Example 4-bit .ico file that fails to load before but loads with this patch:
![](https://raw.githubusercontent.com/SpaceManiac/HamSandwich/85195a3ded9bee533e943afd21a546af27331305/source/eddie/eddie.ico)

PR'd to `release-2.6.x` branch out of optimism that this fix could make it into a future 2.x release; I don't know your backport policy. Can rebase if needed.