### PR TITLE
Fix unused parameter warning

### DIFF
--- a/IMG_tif.c
+++ b/IMG_tif.c
@@ -235,12 +235,16 @@ void IMG_QuitTIF()
 /* See if an image is contained in a data source */
 int IMG_isTIF(SDL_RWops *src)
 {
+    (void)src;
+
     return(0);
 }
 
 /* Load a TIFF type image from an SDL datasource */
 SDL_Surface *IMG_LoadTIF_RW(SDL_RWops *src)
 {
+    (void)src;
+
     return(NULL);
 }
 

--- a/IMG_webp.c
+++ b/IMG_webp.c
@@ -207,7 +207,7 @@ SDL_Surface *IMG_LoadWEBP_RW(SDL_RWops *src)
     } else {
        format = SDL_PIXELFORMAT_RGB24;
     }
-    
+
     surface = SDL_CreateSurface(features.width, features.height, format);
     if (surface == NULL) {
         error = "Failed to allocate SDL_Surface";
@@ -302,7 +302,7 @@ IMG_Animation *IMG_LoadWEBPAnimation_RW(SDL_RWops *src)
     } else {
        format = SDL_PIXELFORMAT_RGB24;
     }
-    
+
     wd.size = raw_data_size;
     wd.bytes = raw_data;
     dmuxer = lib.WebPDemuxInternal(&wd, 0, NULL, WEBP_DEMUX_ABI_VERSION);
@@ -386,16 +386,23 @@ void IMG_QuitWEBP()
 /* See if an image is contained in a data source */
 int IMG_isWEBP(SDL_RWops *src)
 {
+    (void)src;
+
     return 0;
 }
 
 /* Load a WEBP type image from an SDL datasource */
 SDL_Surface *IMG_LoadWEBP_RW(SDL_RWops *src)
 {
+    (void)src;
+
     return NULL;
 }
 
-IMG_Animation *IMG_LoadWEBPAnimation_RW(SDL_RWops *src) {
+IMG_Animation *IMG_LoadWEBPAnimation_RW(SDL_RWops *src)
+{
+    (void)src;
+
     return NULL;
 }
 


### PR DESCRIPTION
Just fix unused parameter for non-supported loaders yet.

```
/home/markand/dev/github/SDL_image/IMG_tif.c: In function ‘IMG_isTIF’:
/home/markand/dev/github/SDL_image/IMG_tif.c:236:26: warning: unused parameter ‘src’ [-Wunused-parameter]
  236 | int IMG_isTIF(SDL_RWops *src)
      |               ~~~~~~~~~~~^~~
/home/markand/dev/github/SDL_image/IMG_tif.c: In function ‘IMG_LoadTIF_RW’:
/home/markand/dev/github/SDL_image/IMG_tif.c:242:40: warning: unused parameter ‘src’ [-Wunused-parameter]
  242 | SDL_Surface *IMG_LoadTIF_RW(SDL_RWops *src)
      |                             ~~~~~~~~~~~^~~
[ 65%] Building C object CMakeFiles/SDL3_image.dir/IMG_webp.c.o
/home/markand/dev/github/SDL_image/IMG_webp.c: In function ‘IMG_isWEBP’:
/home/markand/dev/github/SDL_image/IMG_webp.c:387:27: warning: unused parameter ‘src’ [-Wunused-parameter]
  387 | int IMG_isWEBP(SDL_RWops *src)
      |                ~~~~~~~~~~~^~~
/home/markand/dev/github/SDL_image/IMG_webp.c: In function ‘IMG_LoadWEBP_RW’:
/home/markand/dev/github/SDL_image/IMG_webp.c:393:41: warning: unused parameter ‘src’ [-Wunused-parameter]
  393 | SDL_Surface *IMG_LoadWEBP_RW(SDL_RWops *src)
      |                              ~~~~~~~~~~~^~~
/home/markand/dev/github/SDL_image/IMG_webp.c: In function ‘IMG_LoadWEBPAnimation_RW’:
/home/markand/dev/github/SDL_image/IMG_webp.c:398:52: warning: unused parameter ‘src’ [-Wunused-parameter]
  398 | IMG_Animation *IMG_LoadWEBPAnimation_RW(SDL_RWops *src) {
```

Happens with default CMake configuration on Fedora 37.