### PR TITLE
Fix warnings caused by -Wstatic-in-inline

### DIFF
--- a/tiny_jpeg.h
+++ b/tiny_jpeg.h
@@ -173,10 +173,12 @@ int tje_encode_with_func(tje_write_func* func,
 
 
 #if defined(_MSC_VER)
-#define TJEI_FORCE_INLINE __forceinline
+#define TJEI_FORCE_INLINE static __forceinline
 // #define TJEI_FORCE_INLINE __declspec(noinline)  // For profiling
+#elif ((defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__))
+#define TJEI_FORCE_INLINE  __attribute__((always_inline)) static __inline
 #else
-#define TJEI_FORCE_INLINE static // TODO: equivalent for gcc & clang
+#define TJEI_FORCE_INLINE static __inline
 #endif
 
 // Only use zero for debugging and/or inspection.


### PR DESCRIPTION
Define TJEI_FORCE_INLINE as static __forceinline

This fixes the following warning(s) when built with clang on Windows:
```
warning: static function 'tjei_write' is used in an inline function with external linkage [-Wstatic-in-inline]
note: use 'static' to give inline function 'tjei_write_bits' internal linkage
note: expanded from macro 'TJEI_FORCE_INLINE'
```

Fixes #349