### PR TITLE
cmake: remove ability to build standalone tests + relocatable sdl3-image.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,13 @@ else()
 endif()
 
 set(sdl3image_install_enableable ON)
-if ((TARGET SDL3 OR TARGET SDL3-static) AND SDL3_DISABLE_INSTALL)
+if((TARGET SDL3-shared OR TARGET SDL3-static) AND SDL_DISABLE_INSTALL)
     # Cannot install SDL3_image when SDL3 is built in same built, and is not installed.
     set(sdl3image_install_enableable OFF)
+endif()
+
+if(NOT DEFINED CMAKE_FIND_PACKAGE_PREFER_CONFIG)
+    set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 endif()
 
 include(CMakeDependentOption)
@@ -65,6 +69,7 @@ option(SDL3IMAGE_SAMPLES "Build the SDL3_image sample program(s)" ${SDL3IMAGE_SA
 cmake_dependent_option(SDL3IMAGE_SAMPLES_INSTALL "Install the SDL3_image sample program(s)" OFF "SDL3IMAGE_SAMPLES;SDL3IMAGE_INSTALL" OFF)
 
 option(SDL3IMAGE_TESTS "Build unit tests?" OFF)
+option(SDL3IMAGE_TESTS_INSTALL "Install unit tests?" OFF)
 
 option(SDL3IMAGE_BACKEND_STB "Use stb_image for loading JPEG and PNG files" ON)
 cmake_dependent_option(SDL3IMAGE_BACKEND_WIC "Add WIC backend (Windows Imaging Component)" OFF WIN32 OFF)
@@ -172,7 +177,7 @@ else()
     set(sdl3_target_name SDL3::SDL3)
 endif()
 
-if(NOT TARGET SDL3::Headers)
+if(NOT TARGET SDL3::Headers OR NOT TARGET ${sdl3_target_name})
     find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED COMPONENTS ${sdl_required_components})
 endif()
 
@@ -645,6 +650,7 @@ if(SDL3IMAGE_WEBP)
         add_library(WebP::webpdemux ALIAS webpdemux)
         list(APPEND INSTALL_EXTRA_TARGETS webp webpdemux)
         set_target_properties(webp PROPERTIES EXPORT_NAME "external_libwebp")
+        set_target_properties(webpdemux PROPERTIES EXPORT_NAME "external_webpdemux")
         add_library(SDL3_image::external_libwebp ALIAS webp)
     else()
         message(STATUS "${PROJECT_NAME}: Using system libwebp")
@@ -721,6 +727,7 @@ if(SDL3IMAGE_INSTALL)
         set(SDL3IMAGE_INSTALL_CMAKEDIR_ROOT_DEFAULT "${CMAKE_INSTALL_LIBDIR}/cmake")
     endif()
     set(SDL3IMAGE_INSTALL_CMAKEDIR_ROOT "${SDL3IMAGE_INSTALL_CMAKEDIR_ROOT_DEFAULT}" CACHE STRING "Root folder where to install SDL3Config.cmake related files (SDL3 subfolder for MSVC projects)")
+    set(SDLIMAGE_PKGCONFIG_INSTALLDIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
     if(WIN32 AND NOT MINGW)
         set(SDL3IMAGE_INSTALL_CMAKEDIR "${SDL3IMAGE_INSTALL_CMAKEDIR_ROOT}")
@@ -752,19 +759,17 @@ if(SDL3IMAGE_INSTALL)
         COMPONENT devel
     )
 
+    file(RELATIVE_PATH SDL_PATH_PREFIX_RELATIVE_TO_PKGCONFIG "${CMAKE_INSTALL_PREFIX}/${SDLIMAGE_PKGCONFIG_INSTALLDIR}" "${CMAKE_INSTALL_PREFIX}")
+    string(REGEX REPLACE "[/]+$" "" SDL_PATH_PREFIX_RELATIVE_TO_PKGCONFIG "${SDL_PATH_PREFIX_RELATIVE_TO_PKGCONFIG}")
+    set(SDL_PKGCONFIG_PREFIX "\${pcfiledir}/${SDL_PATH_PREFIX_RELATIVE_TO_PKGCONFIG}")
+
     string(JOIN " " PC_REQUIRES ${PC_REQUIRES})
     string(JOIN " " PC_LIBS ${PC_LIBS})
     configure_file(cmake/sdl3-image.pc.in sdl3-image.pc @ONLY)
 
-    if(CMAKE_SYSTEM_NAME MATCHES FreeBSD)
-        # FreeBSD uses ${PREFIX}/libdata/pkgconfig
-        set(PC_DESTDIR "libdata/pkgconfig")
-    else()
-        set(PC_DESTDIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-    endif()
     # Always install sdl3-image.pc file: libraries might be different between config modes
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/sdl3-image.pc"
-        DESTINATION "${PC_DESTDIR}" COMPONENT devel)
+        DESTINATION "${SDLIMAGE_PKGCONFIG_INSTALLDIR}" COMPONENT devel)
 
     install(FILES "LICENSE.txt"
         DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/licenses/${PROJECT_NAME}"

--- a/cmake/SDL3_imageConfig.cmake.in
+++ b/cmake/SDL3_imageConfig.cmake.in
@@ -37,56 +37,58 @@ set(SDL3IMAGE_BACKEND_WIC       @SDL3IMAGE_BACKEND_WIC@)
 
 set(SDL3IMAGE_SDL3_REQUIRED_VERSION  @SDL_REQUIRED_VERSION@)
 
-if(NOT SDL3IMAGE_VENDORED)
-    set(_sdl_cmake_module_path "${CMAKE_MODULE_PATH}")
-    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
-endif()
-
-include(CMakeFindDependencyMacro)
-
-if(SDL3IMAGE_AVIF AND NOT SDL3IMAGE_VENDORED AND NOT TARGET avif)
-    find_dependency(libavif @LIBAVIF_MINIMUM_VERSION@)
-endif()
-
-if(SDL3IMAGE_JPG AND NOT SDL3IMAGE_VENDORED AND NOT TARGET JPEG::JPEG)
-    find_dependency(JPEG)
-endif()
-
-if(SDL3IMAGE_JXL AND NOT SDL3IMAGE_VENDORED AND NOT TARGET libjxl::libjxl)
-    list(APPEND libjxl_ROOT "${CMAKE_CURRENT_LIST_DIR}")
-    find_dependency(libjxl)
-endif()
-
-if(SDL3IMAGE_PNG AND NOT SDL3IMAGE_VENDORED AND NOT TARGET PNG::PNG)
-    find_dependency(PNG)
-endif()
-
-if(SDL3IMAGE_TIF AND NOT SDL3IMAGE_VENDORED AND NOT TARGET TIFF::TIFF)
-    find_dependency(TIFF)
-endif()
-
-if(SDL3IMAGE_WEBP AND NOT SDL3IMAGE_VENDORED AND NOT TARGET WebP::webp)
-    list(APPEND webp_ROOT "${CMAKE_CURRENT_LIST_DIR}")
-    find_dependency(webp)
-endif()
-
-#FIXME: can't add SDL3IMAGE_SDL3_REQUIRED_VERSION since not all SDL3 installs ship SDL3ConfigVersion.cmake
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL3_image-shared-targets.cmake")
     include("${CMAKE_CURRENT_LIST_DIR}/SDL3_image-shared-targets.cmake")
 endif()
 
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/SDL3_image-static-targets.cmake")
-    include(CheckLanguage)
-    check_language(CXX)
-    if(SDL3IMAGE_VENDORED AND NOT CMAKE_CXX_COMPILER AND NOT _sdl3image_nowarning)
-        message(WARNING "CXX language not enabled. Linking to SDL3_image::SDL3_image-static might fail.")
-    endif()
-    include("${CMAKE_CURRENT_LIST_DIR}/SDL3_image-static-targets.cmake")
-endif()
 
-if(NOT SDL3IMAGE_VENDORED)
-    set(CMAKE_MODULE_PATH "${_sdl_cmake_module_path}")
-    unset(_sdl_cmake_module_path)
+    if(SDL3IMAGE_VENDORED)
+        if(SDL3IMAGE_JXL)
+            include(CheckLanguage)
+            check_language(CXX)
+            if(NOT CMAKE_CXX_COMPILER AND NOT _sdl3image_nowarning)
+                message(WARNING "CXX language not enabled. Linking to SDL3_image::SDL3_image-static might fail.")
+            endif()
+        endif()
+    else()
+        set(_sdl_cmake_module_path "${CMAKE_MODULE_PATH}")
+        list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+        include(CMakeFindDependencyMacro)
+
+        if(SDL3IMAGE_AVIF AND NOT TARGET avif)
+            find_dependency(libavif @LIBAVIF_MINIMUM_VERSION@)
+        endif()
+
+        if(SDL3IMAGE_JPG AND NOT TARGET JPEG::JPEG)
+            find_dependency(JPEG)
+        endif()
+
+        if(SDL3IMAGE_JXL AND NOT TARGET libjxl::libjxl)
+            list(APPEND libjxl_ROOT "${CMAKE_CURRENT_LIST_DIR}")
+            find_dependency(libjxl)
+        endif()
+
+        if(SDL3IMAGE_PNG AND NOT TARGET PNG::PNG)
+            find_dependency(PNG)
+        endif()
+
+        if(SDL3IMAGE_TIF AND NOT TARGET TIFF::TIFF)
+            find_dependency(TIFF)
+        endif()
+
+        if(SDL3IMAGE_WEBP AND NOT TARGET WebP::webp)
+            list(APPEND webp_ROOT "${CMAKE_CURRENT_LIST_DIR}")
+            find_dependency(webp)
+        endif()
+
+        set(CMAKE_MODULE_PATH "${_sdl_cmake_module_path}")
+        unset(_sdl_cmake_module_path)
+
+    endif()
+
+    include("${CMAKE_CURRENT_LIST_DIR}/SDL3_image-static-targets.cmake")
 endif()
 
 function(_sdl_create_target_alias_compat NEW_TARGET TARGET)

--- a/cmake/sdl3-image.pc.in
+++ b/cmake/sdl3-image.pc.in
@@ -1,4 +1,4 @@
-prefix=@CMAKE_INSTALL_PREFIX@
+prefix=@SDL_PKGCONFIG_PREFIX@
 exec_prefix=${prefix}
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@

--- a/cmake/test/CMakeLists.txt
+++ b/cmake/test/CMakeLists.txt
@@ -20,7 +20,7 @@ if(TEST_SHARED)
     find_package(SDL3 REQUIRED CONFIG COMPONENTS SDL3)
     find_package(SDL3_image REQUIRED CONFIG)
     add_executable(main_shared main.c)
-    target_link_libraries(main_shared PRIVATE SDL3_image::SDL3_image SDL3::SDL3)
+    target_link_libraries(main_shared PRIVATE SDL3_image::SDL3_image-shared SDL3::SDL3)
 endif()
 
 if(TEST_STATIC)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,31 +1,6 @@
-cmake_minimum_required(VERSION 3.0)
-project(SDL3_image_tests)
+# CMake script for building SDL_image tests
 
 enable_testing()
-
-option(SDL3IMAGE_TESTS_LINK_SHARED "link tests to shared SDL_image library" ${BUILD_SHARED_LIBS})
-option(SDL3IMAGE_TESTS_INSTALL "Install unit tests?" OFF)
-
-set(SDL_REQUIRED_VERSION 3.0.0)
-
-if(SDL3IMAGE_TESTS_LINK_SHARED)
-    set(sdlimage_target_name SDL3_image::SDL3_image-shared)
-else()
-    set(sdlimage_target_name SDL3_image::SDL3_image-static)
-endif()
-
-if(NOT TARGET SDL3::SDL3 OR NOT TARGET SDL3::SDL3_test)
-    find_package(SDL3 ${SDL_REQUIRED_VERSION} REQUIRED COMPONENTS SDL3 SDL3_test)
-    if(NOT TARGET SDL3::SDL3 OR NOT TARGET SDL3::SDL3_test)
-        message(FATAL_ERROR "find_package(SDL3) did not create SDL3::SDL3.")
-    endif()
-endif()
-if(NOT TARGET ${sdlimage_target_name})
-    find_package(SDL3_image 3.0.0 REQUIRED)
-    if(NOT TARGET ${sdlimage_target_name})
-        message(FATAL_ERROR "find_package(SDL3_image) did not create ${sdlimage_target_name}.")
-    endif()
-endif()
 
 add_executable(testimage main.c)
 
@@ -70,7 +45,7 @@ foreach(prog IN LISTS ALL_TESTS)
         "SDL_IMAGE_SAVE_PNG=$<BOOL:${SDL3IMAGE_PNG_SAVE}>"
     )
     sdl_add_warning_options(${prog} WARNING_AS_ERROR ${SDL3IMAGE_WERROR})
-    target_link_libraries(${prog} PRIVATE ${sdlimage_target_name} SDL3::SDL3_test SDL3::SDL3)
+    target_link_libraries(${prog} PRIVATE SDL3_image::SDL3_image SDL3::SDL3_test SDL3::SDL3)
     if(TARGET sdl3image_build_options)
         target_link_libraries(${prog} PRIVATE $<BUILD_INTERFACE:sdl3image_build_options>)
     endif()


### PR DESCRIPTION
- It's not possible anymore to build the SDL_image tests as a standalone project
- make `sdl3-image.pc` relocatable (you can move the install prefix of SDL_image without worrying about absolute paths)