### PR TITLE
Update test/template.test.in for build system changes

### DIFF
--- a/test/template.test.in
+++ b/test/template.test.in
@@ -1,3 +1,3 @@
 [Test]
 Type=session
-Exec=@installedtestsdir@/@exe@
+Exec=@installedtestsdir@/@TARGET@


### PR DESCRIPTION
The build system switched from naming the executable ${exe} to naming it ${TARGET}.

Fixes: 9ed663af "cmake: use add_sdl_image_test_executable function"