### PR TITLE
Export dynamic and static library names in sdl2_image-config  cmake input file

### DIFF
--- a/sdl2_image-config.cmake.in
+++ b/sdl2_image-config.cmake.in
@@ -64,32 +64,32 @@ unset(libdir)
 
 include(CMakeFindDependencyMacro)
 
-if(NOT TARGET SDL2_image::SDL2_image)
-    add_library(SDL2_image::SDL2_image SHARED IMPORTED)
-    set_target_properties(SDL2_image::SDL2_image
+if(NOT TARGET ${SDL2_IMAGE_LIBRARIES})
+    add_library(${SDL2_IMAGE_LIBRARIES} SHARED IMPORTED)
+    set_target_properties(${SDL2_IMAGE_LIBRARIES}
         PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${_sdl2image_incdir}"
             COMPATIBLE_INTERFACE_BOOL "SDL2_SHARED"
             INTERFACE_SDL2_SHARED "ON"
     )
     if(WIN32)
-        set_target_properties(SDL2_image::SDL2_image
+        set_target_properties(${SDL2_IMAGE_LIBRARIES}
             PROPERTIES
                 IMPORTED_LOCATION "${_sdl2image_bindir}/SDL2_image.dll"
                 IMPORTED_IMPLIB "${_sdl2image_libdir}/${CMAKE_STATIC_LIBRARY_PREFIX}SDL2_image.dll${CMAKE_STATIC_LIBRARY_SUFFIX}"
         )
     else()
-        set_target_properties(SDL2_image::SDL2_image
+        set_target_properties(${SDL2_IMAGE_LIBRARIES}
             PROPERTIES
                 IMPORTED_LOCATION "${_sdl2image_libdir}/${CMAKE_SHARED_LIBRARY_PREFIX}SDL2_image${CMAKE_SHARED_LIBRARY_SUFFIX}"
         )
     endif()
 endif()
 
-if(NOT TARGET SDL2_image::SDL2_image-static)
-    add_library(SDL2_image::SDL2_image-static STATIC IMPORTED)
+if(NOT TARGET ${SDL2_IMAGE_STATIC_LIBRARIES})
+    add_library(${SDL2_IMAGE_STATIC_LIBRARIES} STATIC IMPORTED)
 
-    set_target_properties(SDL2_image::SDL2_image-static
+    set_target_properties(${SDL2_IMAGE_STATIC_LIBRARIES}
         PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${_sdl2image_incdir}"
             IMPORTED_LOCATION "${_sdl2image_libdir}/${CMAKE_STATIC_LIBRARY_PREFIX}SDL2_image${CMAKE_STATIC_LIBRARY_SUFFIX}"

--- a/sdl2_image-config.cmake.in
+++ b/sdl2_image-config.cmake.in
@@ -8,6 +8,9 @@ set_package_properties(SDL2_image PROPERTIES
 
 set(SDL2_image_FOUND TRUE)
 
+set(SDL2_IMAGE_LIBRARIES SDL2_image::SDL2_image)
+set(SDL2_IMAGE_STATIC_LIBRARIES SDL2_image::SDL2_image-static)
+
 set(SDL2IMAGE_AVIF  @LOAD_AVIF@)
 set(SDL2IMAGE_BMP   @LOAD_BMP@)
 set(SDL2IMAGE_GIF   @LOAD_GIF@)


### PR DESCRIPTION
I am opening this PR to export `SDL2_image` library names (whether it is dynamic or static) so end user may call them just using a variable as it done in `SDL2`

Currently, a `CMakeFile.txt` has to be like
```
...
target_link_libraries(${PROJECT_NAME} ${SDL2_LIBRARIES} SDL2_image::SDL2_image)
...
```

And with this fix, we can call it using

```
target_link_libraries(${PROJECT_NAME} ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES})
or
target_link_libraries(${PROJECT_NAME} ${SDL2_LIBRARIES} ${SDL2_IMAGE_STATIC_LIBRARIES})
```

I kept the same format as `SDL2` so users may expect similar naming

---

P.S.: I don't why `SDL2` exports the variables but does not use them inside `sdl2-config.cmake` itself. I mean, they
```
set(SDL2_LIBRARIES SDL2::SDL2)                                                   
set(SDL2_STATIC_LIBRARIES SDL2::SDL2-static)
```
but then
```
if(TARGET SDL2::SDL2-static AND NOT TARGET SDL2::SDL2)
```
instead of
```
if(TARGET ${SDL2_STATIC_LIBRARIES} AND NOT TARGET ${SDL2_LIBRARIES})
```

I did test both cases (dynamic and static) here and I could remove the hardcoded `SDL2_image::SDL2_image` and `SDL2_image::SDL2_image-static` from the entire file.

---

When using dynamic (`target_link_libraries(${PROJECT_NAME} ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES})`):
```
$readelf -d test
Dynamic section at offset 0x52d88 contains 32 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libSDL2-2.0.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libSDL2_image-2.0.so.0] <-- IMG_Load will be loaded from here
...
 0x000000000000001d (RUNPATH)            Library runpath: [/opt/SDL2-2.28.2/lib:/home/user/SDL2_image-2.6.3_fixed/lib]



$readelf -s test
Symbol table '.dynsym' contains 122 entries:
...
101: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND IMG_Load  <-- IMG_Load call is present in .dynsym, so code
                                                                      is not in this binary

```

When using static (`target_link_libraries(${PROJECT_NAME} ${SDL2_LIBRARIES} ${SDL2_IMAGE_STATIC_LIBRARIES})`):
```
$readelf -d test
Dynamic section at offset 0x78d88 contains 31 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libSDL2-2.0.so.0]
...
 0x000000000000001d (RUNPATH)            Library runpath: [/opt/SDL2-2.28.2/lib] <-- No SDL2_image will be searched



readelf -s test
Symbol table '.symtab' contains 3595 entries:
3262: 0000000000035fa0    89 FUNC    GLOBAL DEFAULT   14 IMG_Load <--- because IMG_Load code is here in binary =)
```

Please do let me know if I am doing something wrong in removing the hardcoded names

Best regards