### PR TITLE
Use CMAKE_CURRENT_*_DIR instead of CMAKE_*_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(MINOR_VERSION 0)
 set(MICRO_VERSION 0)
 set(SDL_REQUIRED_VERSION 3.0.0)
 
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
     message(FATAL_ERROR "Prevented in-tree built. Please create a build directory outside of the SDL_image source code and call cmake from there")
 endif()
 


### PR DESCRIPTION
This PR allows for building with cmake's [add_subdirectory](https://cmake.org/cmake/help/latest/command/add_subdirectory.html#command:add_subdirectory) function, like so:

# Build and include SDL in main project
```shell
add_subdirectory(lib/SDL2_image lib/SDL2_image_BIN EXCLUDE_FROM_ALL)
target_link_libraries(main PRIVATE SDL2_image)
```