### PR TITLE
Fix regression (segfault) in LBM image loading [SDL2 branch]

### DIFF
--- a/src/IMG_lbm.c
+++ b/src/IMG_lbm.c
@@ -259,11 +259,9 @@ SDL_Surface *IMG_LoadLBM_RW( SDL_RWops *src )
           format = SDL_PIXELFORMAT_BGR24;
 #endif
        }
-       if (nbplanes == 24 || flagHAM == 1) {
-          if ((Image = SDL_CreateRGBSurfaceWithFormat(0, width, bmhd.h, 0, format)) == NULL ){
-             goto done;
-          }
-       }
+        if ((Image = SDL_CreateRGBSurfaceWithFormat(0, width, bmhd.h, 0, format)) == NULL){
+            goto done;
+        }
     }
 
     if ( bmhd.mask & 2 )               /* There is a transparent color */


### PR DESCRIPTION
The PR https://github.com/libsdl-org/SDL_image/pull/318 introduced a regression, loading some kinds of `LBM` files now segfaults. 

[Here](https://github.com/libsdl-org/SDL_image/files/13696574/magenta.zip) is a zip that contains one such LBM file that segfaults on 2.8.x but not on earlier versions.

This PR does a simple fix
