### PR TITLE
IMG_SavePNG / libpng: handle errors at one place, so that libpng/setj…

### DIFF
--- a/src/IMG_png.c
+++ b/src/IMG_png.c
@@ -656,6 +656,8 @@ static int IMG_SavePNG_RW_libpng(SDL_Surface *surface, SDL_RWops *dst)
            format , so it should be converted to that */
         png_color_type = PNG_COLOR_TYPE_RGB_ALPHA;
         source = SDL_ConvertSurfaceFormat(surface, png_format);
+    } else {
+        png_color_type = PNG_COLOR_TYPE_RGB_ALPHA;
     }
 
     lib.png_set_write_fn(png_ptr, dst, png_write_data, png_flush_data);


### PR DESCRIPTION
IMG_SavePNG / libpng: handle errors at one place, so that libpng/setjump() can also free resources if an error occurs. (see #416)