### PR TITLE
Casts to fix pointer type errors.

### DIFF
--- a/IMG_png.c
+++ b/IMG_png.c
@@ -266,15 +266,15 @@ void IMG_QuitPNG()
 int IMG_InitPNG()
 {
 	if ( lib.loaded == 0 ) {
-		lib.png_create_info_struct = png_create_info_struct;
+		lib.png_create_info_struct = (png_info * (*)(png_struct *))png_create_info_struct;
 		lib.png_create_read_struct = png_create_read_struct;
 		lib.png_destroy_read_struct = png_destroy_read_struct;
-		lib.png_get_IHDR = png_get_IHDR;
-		lib.png_get_channels = png_get_channels;
-		lib.png_get_io_ptr = png_get_io_ptr;
-		lib.png_get_PLTE = png_get_PLTE;
-		lib.png_get_tRNS = png_get_tRNS;
-		lib.png_get_valid = png_get_valid;
+		lib.png_get_IHDR = (png_uint_32 (*)(png_struct *, png_info *, png_uint_32 *, png_uint_32 *, int *, int *, int *, int *, int *))png_get_IHDR;
+		lib.png_get_channels = (png_byte (*)(png_struct *, png_info *))png_get_channels;
+		lib.png_get_io_ptr = (void * (*)(png_struct *))png_get_io_ptr;
+		lib.png_get_PLTE = (png_uint_32 (*)(png_struct *, png_info *, png_color **, int *))png_get_PLTE;
+		lib.png_get_tRNS = (png_uint_32 (*)(png_struct *, png_info *, png_byte **, int *, png_color_16 **))png_get_tRNS;
+		lib.png_get_valid = (png_uint_32 (*)(png_struct *, png_info *, png_uint_32))png_get_valid;
 		lib.png_read_image = png_read_image;
 		lib.png_read_info = png_read_info;
 		lib.png_read_update_info = png_read_update_info;
@@ -284,7 +284,7 @@ int IMG_InitPNG()
 		lib.png_set_read_fn = png_set_read_fn;
 		lib.png_set_strip_16 = png_set_strip_16;
 		lib.png_set_interlace_handling = png_set_interlace_handling;
-		lib.png_sig_cmp = png_sig_cmp;
+		lib.png_sig_cmp = (int (*)(png_byte *, png_size_t,  png_size_t))png_sig_cmp;
 #ifndef LIBPNG_VERSION_12
 		lib.png_set_longjmp_fn = png_set_longjmp_fn;
 #endif


### PR DESCRIPTION
This initiative: https://fedoraproject.org/wiki/Toolchain/PortingToModernC

Led to these being errors:

`IMG_png.c: In function ‘IMG_InitPNG’:
IMG_png.c:274:44: error: assignment to ‘png_info * (*)(png_struct *)’ {aka ‘struct png_info_def * (*)(struct png_struct_def *)’} from incompatible pointer type ‘png_info * (*)(const png_struct * restrict)’ {aka ‘struct png_info_def * (*)(const struct png_struct_def * restrict)’} [-Wincompatible-pointer-types]
  274 |                 lib.png_create_info_struct = png_create_info_struct;
      |                                            ^
IMG_png.c:277:34: error: assignment to ‘png_uint_32 (*)(png_struct *, png_info *, png_uint_32 *, png_uint_32 *, int *, int *, int *, int *, int *)’ {aka ‘unsigned int (*)(struct png_struct_def *, struct png_info_def *, unsigned int *, unsigned int *, int *, int *, int *, int *, int *)’} from incompatible pointer type ‘png_uint_32 (*)(const png_struct * restrict,  const png_info * restrict,  png_uint_32 *, png_uint_32 *, int *, int *, int *, int *, int *)’ {aka ‘unsigned int (*)(const struct png_struct_def * restrict,  const struct png_info_def * restrict,  unsigned int *, unsigned int *, int *, int *, int *, int *, int *)’} [-Wincompatible-pointer-types]
  277 |                 lib.png_get_IHDR = png_get_IHDR;
      |                                  ^
IMG_png.c:278:38: error: assignment to ‘png_byte (*)(png_struct *, png_info *)’ {aka ‘unsigned char (*)(struct png_struct_def *, struct png_info_def *)’} from incompatible pointer type ‘png_byte (*)(const png_struct * restrict,  const png_info * restrict)’ {aka ‘unsigned char (*)(const struct png_struct_def * restrict,  const struct png_info_def * restrict)’} [-Wincompatible-pointer-types]
  278 |                 lib.png_get_channels = png_get_channels;
      |                                      ^
IMG_png.c:279:36: error: assignment to ‘void * (*)(png_struct *)’ {aka ‘void * (*)(struct png_struct_def *)’} from incompatible pointer type ‘void * (*)(const png_struct * restrict)’ {aka ‘void * (*)(const struct png_struct_def * restrict)’} [-Wincompatible-pointer-types]
  279 |                 lib.png_get_io_ptr = png_get_io_ptr;
      |                                    ^
IMG_png.c:280:34: error: assignment to ‘png_uint_32 (*)(png_struct *, png_info *, png_color **, int *)’ {aka ‘unsigned int (*)(struct png_struct_def *, struct png_info_def *, struct png_color_struct **, int *)’} from incompatible pointer type ‘png_uint_32 (*)(const png_struct * restrict,  png_info * restrict,  png_color **, int *)’ {aka ‘unsigned int (*)(const struct png_struct_def * restrict,  struct png_info_def * restrict,  struct png_color_struct **, int *)’} [-Wincompatible-pointer-types]
  280 |                 lib.png_get_PLTE = png_get_PLTE;
      |                                  ^
IMG_png.c:281:34: error: assignment to ‘png_uint_32 (*)(png_struct *, png_info *, png_byte **, int *, png_color_16 **)’ {aka ‘unsigned int (*)(struct png_struct_def *, struct png_info_def *, unsigned char **, int *, struct png_color_16_struct **)’} from incompatible pointer type ‘png_uint_32 (*)(const png_struct * restrict,  png_info * restrict,  png_byte **, int *, png_color_16 **)’ {aka ‘unsigned int (*)(const struct png_struct_def * restrict,  struct png_info_def * restrict,  unsigned char **, int *, struct png_color_16_struct **)’} [-Wincompatible-pointer-types]
  281 |                 lib.png_get_tRNS = png_get_tRNS;
      |                                  ^
IMG_png.c:282:35: error: assignment to ‘png_uint_32 (*)(png_struct *, png_info *, png_uint_32)’ {aka ‘unsigned int (*)(struct png_struct_def *, struct png_info_def *, unsigned int)’} from incompatible pointer type ‘png_uint_32 (*)(const png_struct * restrict,  const png_info * restrict,  png_uint_32)’ {aka ‘unsigned int (*)(const struct png_struct_def * restrict,  const struct png_info_def * restrict,  unsigned int)’} [-Wincompatible-pointer-types]
  282 |                 lib.png_get_valid = png_get_valid;
      |                                   ^
IMG_png.c:292:33: error: assignment to ‘int (*)(png_byte *, png_size_t,  png_size_t)’ {aka ‘int (*)(unsigned char *, long unsigned int,  long unsigned int)’} from incompatible pointer type ‘int (*)(const png_byte *, size_t,  size_t)’ {aka ‘int (*)(const unsigned char *, long unsigned int,  long unsigned int)’} [-Wincompatible-pointer-types]
  292 |                 lib.png_sig_cmp = png_sig_cmp;
      |                                 ^`

Which this patch corrects.