### PR TITLE
Fix SDL2IMAGE_TIF_SHARED=ON and SDL2IMAGE_TIF_VENDORED=OFF when using CMake >= 3.28

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -767,12 +767,19 @@ if(SDL2IMAGE_TIF)
     if(SDL2IMAGE_TIF_ENABLED)
         target_compile_definitions(SDL2_image PRIVATE LOAD_TIF)
         if(SDL2IMAGE_TIF_SHARED)
+            # If TIFF::tiff exists, use that one, otherwise
+            # fallback to TIFF:TIFF
+            if(TARGET TIFF::tiff)
+                set(SDL2IMAGE_TIF_IMPORTED_TARGET "TIFF::tiff")
+            else()
+                set(SDL2IMAGE_TIF_IMPORTED_TARGET "TIFF::TIFF")
+            endif()
             target_include_directories(SDL2_image PRIVATE
-                $<TARGET_PROPERTY:TIFF::TIFF,INCLUDE_DIRECTORIES>
-                $<TARGET_PROPERTY:TIFF::TIFF,INTERFACE_INCLUDE_DIRECTORIES>
-                $<TARGET_PROPERTY:TIFF::TIFF,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
+                $<TARGET_PROPERTY:${SDL2IMAGE_TIF_IMPORTED_TARGET},INCLUDE_DIRECTORIES>
+                $<TARGET_PROPERTY:${SDL2IMAGE_TIF_IMPORTED_TARGET},INTERFACE_INCLUDE_DIRECTORIES>
+                $<TARGET_PROPERTY:${SDL2IMAGE_TIF_IMPORTED_TARGET},INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>
             )
-            target_get_dynamic_library(dynamic_tif TIFF::TIFF)
+            target_get_dynamic_library(dynamic_tif ${SDL2IMAGE_TIF_IMPORTED_TARGET})
             message(STATUS "Dynamic libtiff: ${dynamic_tif}")
             target_compile_definitions(SDL2_image PRIVATE "LOAD_TIF_DYNAMIC=\"${dynamic_tif}\"")
             if(SDL2IMAGE_TIF_VENDORED)


### PR DESCRIPTION
When using CMake >= 3.28, the build on Windows can fail with the following error:
~~~
-- Found TIFF: D:/bld/sdl2_image_1711371034934/_h_env/Library/lib/cmake/tiff (found version "4.6.0")
CMake Error at cmake/PrivateSdlFunctions.cmake:247 (message):
  TIFF::TIFF is not a shared library, but has type=INTERFACE_LIBRARY
-- Dynamic libtiff: $<TARGET_FILE_NAME:TIFF::TIFF>
Call Stack (most recent call first):
-- SDL2_image: Using system libwebp
~~~

The error is due to https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8803, that changed `TIFF::TIFF` to be an interface library that just acts as a sort of alias to `TIFF::tiff`. This PR fixes this problem by using `TIFF::tiff` if it is defined, and just use `TIFF::TIFF` if `TIFF::tiff` is not defined.