### PR TITLE
Migrate an SDL2 symbol to the SDL3 one

### DIFF
--- a/src/IMG_png.c
+++ b/src/IMG_png.c
@@ -371,13 +371,13 @@ static void LIBPNG_LoadPNG_IO(SDL_IOStream *src, struct loadpng_vars *vars)
              format = SDL_PIXELFORMAT_INDEX8;
              break;
           case 12:
-             format = SDL_PIXELFORMAT_RGB444;
+             format = SDL_PIXELFORMAT_XRGB4444;
              break;
           case 15:
-             format = SDL_PIXELFORMAT_RGB555;
+             format = SDL_PIXELFORMAT_XRGB1555;
              break;
           case 16:
-             format = SDL_PIXELFORMAT_RGB565;
+             format = SDL_PIXELFORMAT_XRGB8888;
              break;
 
           default:

--- a/src/IMG_png.c
+++ b/src/IMG_png.c
@@ -377,7 +377,7 @@ static void LIBPNG_LoadPNG_IO(SDL_IOStream *src, struct loadpng_vars *vars)
              format = SDL_PIXELFORMAT_XRGB1555;
              break;
           case 16:
-             format = SDL_PIXELFORMAT_XRGB8888;
+             format = SDL_PIXELFORMAT_RGB565;
              break;
 
           default:

--- a/src/IMG_tga.c
+++ b/src/IMG_tga.c
@@ -156,7 +156,7 @@ SDL_Surface *IMG_LoadTGA_IO(SDL_IOStream *src)
     case 16:
         /* 15 and 16bpp both seem to use 5 bits/plane. The extra alpha bit
            is ignored for now. */
-        format = SDL_PIXELFORMAT_RGB555;
+        format = SDL_PIXELFORMAT_XRGB1555;
         break;
 
     case 32:


### PR DESCRIPTION
Changed `SDL_PIXELFORMAT_RGB555` to `SDL_PIXELFORMAT_XRGB1555`.

Been building for android and this makes the build fail, so I fixed it.