### PR TITLE
IMG_*: fix remaining cases of incorrect attribute placement

### DIFF
--- a/src/IMG_avif.c
+++ b/src/IMG_avif.c
@@ -84,11 +84,11 @@ static struct {
     if (lib.FUNC == NULL) { IMG_SetError("Missing avif.framework"); return -1; }
 #endif
 
-int IMG_InitAVIF(void)
 #ifdef __APPLE__
     /* Need to turn off optimizations so weak framework load check works */
     __attribute__ ((optnone))
 #endif
+int IMG_InitAVIF(void)
 {
     if ( lib.loaded == 0 ) {
 #ifdef LOAD_AVIF_DYNAMIC

--- a/src/IMG_jxl.c
+++ b/src/IMG_jxl.c
@@ -52,11 +52,11 @@ static struct {
     if (lib.FUNC == NULL) { IMG_SetError("Missing jxl.framework"); return -1; }
 #endif
 
-int IMG_InitJXL(void)
 #ifdef __APPLE__
     /* Need to turn off optimizations so weak framework load check works */
     __attribute__ ((optnone))
 #endif
+int IMG_InitJXL(void)
 {
     if ( lib.loaded == 0 ) {
 #ifdef LOAD_JXL_DYNAMIC


### PR DESCRIPTION
@slouken @sezero Remaining two instances.

P. S. Missed in the earlier PR because I did not need them to build 2.8.2: apparently, MacPorts skips these files by default.
See also: https://github.com/libsdl-org/SDL_image/pull/463#issuecomment-2287162843