### PR TITLE
cmake: add uninstall target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1078,6 +1078,13 @@ if(SDLIMAGE_INSTALL)
             REVISION "${SDLIMAGE_REVISION}"
         )
     endif()
+
+    if(SDLIMAGE_ROOTPROJECT)
+        configure_file(cmake/cmake_uninstall.cmake.in cmake_uninstall.cmake IMMEDIATE @ONLY)
+
+        add_custom_target(uninstall
+            COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+    endif()
 endif()
 
 if(SDLIMAGE_SAMPLES)

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,17 @@
+if (NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+    message(FATAL_ERROR "Cannot find install manifest: \"@CMAKE_BINARY_DIR@/install_manifest.txt\"")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+    message(STATUS "Uninstalling \"$ENV{DESTDIR}${file}\"")
+    execute_process(
+        COMMAND @CMAKE_COMMAND@ -E remove "$ENV{DESTDIR}${file}"
+        OUTPUT_VARIABLE rm_out
+        RESULT_VARIABLE rm_retval
+    )
+    if(NOT ${rm_retval} EQUAL 0)
+        message(FATAL_ERROR "Problem when removing \"$ENV{DESTDIR}${file}\"")
+    endif (NOT ${rm_retval} EQUAL 0)
+endforeach()


### PR DESCRIPTION
The code is yoinked from the SDL repo. Works fine on my machine.

```
chiller@debian:~/Desktop/git/SDL_image/build$ sudo make install
[sudo] password for chiller: 
[ 84%] Built target SDL3_image-shared
[ 92%] Built target showanim
[100%] Built target showimage
Install the project...
-- Install configuration: ""
-- Installing: /usr/local/lib/libSDL3_image.so.0.1.0
-- Up-to-date: /usr/local/lib/libSDL3_image.so.0
-- Set runtime path of "/usr/local/lib/libSDL3_image.so.0.1.0" to ""
-- Up-to-date: /usr/local/lib/libSDL3_image.so
-- Installing: /usr/local/include/SDL3_image/SDL_image.h
-- Installing: /usr/local/lib/cmake/SDL3_image/SDL3_imageConfig.cmake
-- Installing: /usr/local/lib/cmake/SDL3_image/SDL3_imageConfigVersion.cmake
-- Installing: /usr/local/lib/cmake/SDL3_image/SDL3_image-shared-targets.cmake
-- Installing: /usr/local/lib/cmake/SDL3_image/SDL3_image-shared-targets-noconfig.cmake
-- Installing: /usr/local/lib/pkgconfig/sdl3-image.pc
-- Installing: /usr/local/share/licenses/SDL3_image/LICENSE.txt
chiller@debian:~/Desktop/git/SDL_image/build$ sudo make uninstall
-- Uninstalling "/usr/local/lib/libSDL3_image.so.0.1.0"
-- Uninstalling "/usr/local/lib/libSDL3_image.so.0"
-- Uninstalling "/usr/local/lib/libSDL3_image.so"
-- Uninstalling "/usr/local/include/SDL3_image/SDL_image.h"
-- Uninstalling "/usr/local/lib/cmake/SDL3_image/SDL3_imageConfig.cmake"
-- Uninstalling "/usr/local/lib/cmake/SDL3_image/SDL3_imageConfigVersion.cmake"
-- Uninstalling "/usr/local/lib/cmake/SDL3_image/SDL3_image-shared-targets.cmake"
-- Uninstalling "/usr/local/lib/cmake/SDL3_image/SDL3_image-shared-targets-noconfig.cmake"
-- Uninstalling "/usr/local/lib/pkgconfig/sdl3-image.pc"
-- Uninstalling "/usr/local/share/licenses/SDL3_image/LICENSE.txt"
Built target uninstall
chiller@debian:~/Desktop/git/SDL_image/build$ 
```