### PR TITLE
fix name case of webpdemux target

### DIFF
--- a/cmake/Findwebp.cmake
+++ b/cmake/Findwebp.cmake
@@ -43,7 +43,7 @@ if (webp_FOUND)
             INTERFACE_LINK_FLAGS "${webp_LINK_FLAGS}"
         )
     endif()
-    if (NOT TARGET WEBP::webpdemux)
+    if (NOT TARGET WebP::webpdemux)
         add_library(WebP::webpdemux UNKNOWN IMPORTED)
         set_target_properties(WebP::webpdemux PROPERTIES
             IMPORTED_LOCATION "${webpdemux_LIBRARY}"


### PR DESCRIPTION
I faced an error when building on Linux (via Conan Center Index CI) because of the case mismatch. However, on my local machine running macOS there was no issue. This was for v2.8.2, but I see that v3 has the same issue.

```
sdl_image/2.8.2: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/home/conan/workspace/cci_prod_PR-25991/conan-home/p/b/sdl_ida4af7139f2bc/p" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/home/conan/workspace/cci_prod_PR-25991/conan-home/p/b/sdl_ida4af7139f2bc/b/src"
-- Using Conan toolchain: /home/conan/workspace/cci_prod_PR-25991/conan-home/p/b/sdl_ida4af7139f2bc/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Defining architecture flag: -m64
-- Conan toolchain: Setting BUILD_SHARED_LIBS = ON
-- The C compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/local/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring SDL2_image 2.8.2
-- Performing Test HAVE_WL_NO_UNDEFINED
-- Performing Test HAVE_WL_NO_UNDEFINED - Success
-- SDL2_image: Using system libtiff
-- Conan: Target declared 'TIFF::TIFF'
-- Conan: Component target declared 'libdeflate::libdeflate_shared'
-- Conan: Target declared 'jbig::jbig'
-- Conan: Component target declared 'zstd::libzstd_shared'
-- Conan: Target declared 'JPEG::JPEG'
-- Conan: Component target declared 'WebP::webpdecoder'
-- Conan: Component target declared 'WebP::sharpyuv'
-- Conan: Component target declared 'WebP::webp'
-- Conan: Component target declared 'WebP::webpdemux'
-- Conan: Component target declared 'WebP::libwebpmux'
-- Conan: Target declared 'libwebp::libwebp'
-- SDL2_image: Using system libwebp
-- Found webp: /home/conan/workspace/cci_prod_PR-25991/conan-home/p/libwed5d42768c6b93/p/lib/libwebp.so
CMake Error at cmake/Findwebp.cmake:47 (add_library):
  add_library cannot create imported target "WebP::webpdemux" because another
  target with the same name already exists.
Call Stack (most recent call first):
  CMakeLists.txt:693 (find_package)
```

P.S. Should I also open a PR to 2.x branch? Or you backport fixes on your own?