### PR TITLE
Added `--depth 1` flag for cloning external libraries

### DIFF
--- a/external/Get-GitModules.ps1
+++ b/external/Get-GitModules.ps1
@@ -14,8 +14,13 @@
 [String] $PathRegex   = "path\s*=\s*(?<path>.*)"
 [String] $URLRegex    = "url\s*=\s*(?<url>.*)" 
 [String] $BranchRegex = "branch\s*=\s*(?<Branch>.*)"
+[String] $Arguments   = $($args -join " ")
 
 #------- Script ----------------------------------------------------------------
+if ([string]::IsNullOrEmpty($Arguments)) {
+    $Arguments = "--depth 1"
+}
+
 foreach ($Line in Get-Content $PSScriptRoot\..\.gitmodules) {
     if ($Line -match $PathRegex) {
         $Match  = Select-String -InputObject $Line -Pattern $PathRegex
@@ -29,8 +34,8 @@ foreach ($Line in Get-Content $PSScriptRoot\..\.gitmodules) {
         $Match  = Select-String -InputObject $Line -Pattern $BranchRegex
         $Branch = $Match.Matches[0].Groups[1].Value
         
-        Write-Host "git clone --filter=blob:none $URL $Path -b $Branch --recursive" `
+        Write-Host "git clone --filter=blob:none $URL $Path -b $Branch --recursive $Arguments" `
             -ForegroundColor Blue
-        git clone --filter=blob:none $URL $PSScriptRoot/../$Path -b $Branch --recursive --depth 1
+        git clone --filter=blob:none $URL $PSScriptRoot/../$Path -b $Branch --recursive $Arguments
     }
 }

--- a/external/Get-GitModules.ps1
+++ b/external/Get-GitModules.ps1
@@ -29,7 +29,7 @@ foreach ($Line in Get-Content $PSScriptRoot\..\.gitmodules) {
         $Match  = Select-String -InputObject $Line -Pattern $BranchRegex
         $Branch = $Match.Matches[0].Groups[1].Value
         
-        Write-Host "git clone --filter=blob:none $URL $Path -b $Branch --recursive" `
+        Write-Host "git clone --filter=blob:none $URL $Path -b $Branch --recursive --depth 1" `
             -ForegroundColor Blue
         git clone --filter=blob:none $URL $PSScriptRoot/../$Path -b $Branch --recursive
     }

--- a/external/download.sh
+++ b/external/download.sh
@@ -15,7 +15,7 @@ while true; do
     read line; set -- $line
     branch=$3
 
-    if [ -z "${ARGUMENTS}" ]; then
+    if [ -z "$ARGUMENTS" ]; then
         ARGUMENTS="--depth 1"
     fi
 

--- a/external/download.sh
+++ b/external/download.sh
@@ -14,5 +14,5 @@ while true; do
     url=$3
     read line; set -- $line
     branch=$3
-    git clone --filter=blob:none $url $path -b $branch --recursive $ARGUMENTS
+    git clone --filter=blob:none $url $path -b $branch --recursive $ARGUMENTS --depth 1
 done

--- a/external/download.sh
+++ b/external/download.sh
@@ -19,5 +19,5 @@ while true; do
         ARGUMENTS="--depth 1"
     fi
 
-    git clone --filter=blob:none $url $path -b $branch --recursive $ARGUMENTS --depth 1
+    git clone --filter=blob:none $url $path -b $branch --recursive $ARGUMENTS
 done

--- a/external/download.sh
+++ b/external/download.sh
@@ -14,5 +14,10 @@ while true; do
     url=$3
     read line; set -- $line
     branch=$3
+
+    if [ -z "${ARGUMENTS}" ]; then
+        ARGUMENTS="--depth 1"
+    fi
+
     git clone --filter=blob:none $url $path -b $branch --recursive $ARGUMENTS --depth 1
 done


### PR DESCRIPTION
Not a big change but because my internet speed is always low in my area, I always encounter the problem when external libraries can't be cloned completely (especially libjxl, git failes with RPC call and I assume it's because of country middleboxes...). Everytime, I had to add this flag manually, but I think it won't harm much if it is included in the main repo + it will speed up the download process anyway.