### PR TITLE
Fixed default arguments not being passed properly in external dependencies powershell script

### DIFF
--- a/external/Get-GitModules.ps1
+++ b/external/Get-GitModules.ps1
@@ -14,11 +14,11 @@
 [String] $PathRegex   = "path\s*=\s*(?<path>.*)"
 [String] $URLRegex    = "url\s*=\s*(?<url>.*)" 
 [String] $BranchRegex = "branch\s*=\s*(?<Branch>.*)"
-[String] $Arguments   = $($args -join " ")
+[String[]] $Arguments = $args
 
 #------- Script ----------------------------------------------------------------
-if ([string]::IsNullOrEmpty($Arguments)) {
-    $Arguments = "--depth 1"
+if (-not $Arguments) {
+    [String[]]$Arguments = "--depth", "1"
 }
 
 foreach ($Line in Get-Content $PSScriptRoot\..\.gitmodules) {


### PR DESCRIPTION
Windows handles arguments passed to processes differently. In PowerShell script, need to explicitly pass array of arguments to `git clone` command. This PR addresses that issue.