### PR TITLE
autotools: Eliminate libgcc*.dll dependency in mingw builds. (SDL 1.2)

### DIFF
--- a/configure
+++ b/configure
@@ -12267,6 +12267,8 @@ case "$host" in
         fi
         use_version_rc=true
         LT_EXTRA="-Wl,version.o"
+        # Eliminate libgcc*.dll dependency.
+        CFLAGS="$CFLAGS -static-libgcc"
         ;;
     *-*-darwin*)
         # Check whether --enable-imageio was given.

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,8 @@ case "$host" in
         fi
         use_version_rc=true
         LT_EXTRA="-Wl,version.o"
+        # Eliminate libgcc*.dll dependency.
+        CFLAGS="$CFLAGS -static-libgcc"
         ;;
     *-*-darwin*)
         AC_ARG_ENABLE([imageio], [AS_HELP_STRING([--enable-imageio], [use native Mac OS X frameworks for loading images [default=yes]])],

--- a/ltmain.sh
+++ b/ltmain.sh
@@ -4766,7 +4766,7 @@ func_mode_link ()
       # -p, -pg, --coverage, -fprofile-* pass through profiling flag for GCC
       # @file GCC response files
       -64|-mips[0-9]|-r[0-9][0-9]*|-xarch=*|-xtarget=*|+DA*|+DD*|-q*|-m*| \
-      -t[45]*|-txscale*|-p|-pg|--coverage|-fprofile-*|-F*|@*)
+      -t[45]*|-txscale*|-p|-pg|--coverage|-fprofile-*|-F*|-static-*|@*)
         func_quote_for_eval "$arg"
 	arg="$func_quote_for_eval_result"
         func_append compile_command " $arg"


### PR DESCRIPTION
Cherry-picked from SDL2 commit 4a28594.