### PR TITLE
cmake: adapt to the new vendored libpng cmake'ry :

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,8 +414,7 @@ if(SDLIMAGE_ZLIB)
         sdl_check_project_in_subfolder(external/zlib zlib SDLIMAGE_VENDORED)
         add_subdirectory(external/zlib EXCLUDE_FROM_ALL)
         register_license(zlib external/zlib/LICENSE)
-        # PNG_BUILD_ZLIB variable is used by vendored libpng
-        set(PNG_BUILD_ZLIB ON CACHE BOOL "libpng option to tell it should use 'our' vendored ZLIB library" FORCE)
+        set(ZLIB_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/external/zlib;${CMAKE_CURRENT_BINARY_DIR}/external/zlib")
         # ZLIB_INCLUDE_DIR variable is used by vendored libpng
         set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/zlib;${CMAKE_CURRENT_BINARY_DIR}/external/zlib" CACHE STRING "path of zlib, passed to libpng" FORCE)
         # ZLIB_LIBRARY variable is used by vendored libpng
@@ -423,6 +422,7 @@ if(SDLIMAGE_ZLIB)
             set(ZLIB_LIBRARY zlib)
         else()
             set(ZLIB_LIBRARY zlibstatic)
+            set(SKIP_INSTALL_CONFIG_FILE ON)
         endif()
         if(NOT TARGET ZLIB::ZLIB)
             add_library(ZLIB::ZLIB ALIAS ${ZLIB_LIBRARY})


### PR DESCRIPTION
- do not set PNG_BUILD_ZLIB: it's rejected by libpng with error.
  set ZLIB_ROOT, instead.
- set SKIP_INSTALL_CONFIG_FILE for the SDLIMAGE_ZLIB_SHARED case
  because libpng cmake config fails for zlibstatic.
