### PR TITLE
IMG_webp: Incorrect frame composition in animated WebP loading

### DIFF
--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -382,10 +382,10 @@ IMG_Animation *IMG_LoadWEBPAnimation_RW(SDL_RWops *src)
             }
 
             if (!lib.WebPDecodeRGBAInto(iter.fragment.bytes,
-                iter.fragment.size,
-                (uint8_t*)curr->pixels,
-                curr->pitch * curr->h,
-                curr->pitch)) {
+                                        iter.fragment.size,
+                                        (uint8_t *)curr->pixels,
+                                        curr->pitch * curr->h,
+                                        curr->pitch)) {
                 error = "WebPDecodeRGBAInto() failed";
                 SDL_FreeSurface(curr);
                 goto error;


### PR DESCRIPTION
The current animated WebP loader in SDL_image has incorrect frame composition behavior, leading to visual artifacts in animated WebP files. This is particularly noticeable in WebP animations that use transparency or have overlapping frames with different disposal methods.

some test images here:

https://github.com/inigomonyota/webptestimages