### PR TITLE
fix stbi__parse_png_file() reading too much bytes

### DIFF
--- a/src/stb_image.h
+++ b/src/stb_image.h
@@ -5395,6 +5395,10 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp, unsigned i
             STBI_FREE(z->expanded); z->expanded = NULL;
             // end of PNG chunk, read and skip CRC
             stbi__get32be(s);
+            if (s->io.skip && s->img_buffer_end > s->img_buffer) {
+               // rewind the additional bytes that have been read to the buffer
+               (s->io.skip)(s->io_user_data, (int)(s->img_buffer - s->img_buffer_end));
+            }
             return 1;
          }
 


### PR DESCRIPTION
just "rewind" the bytes that have been read past the IEND chunk.

should fix #360 and #524