### PR TITLE
ISSUE-470: add CoreGraphics, ImageIO, and MobileCoreServices required from `IMG_ImageIO.mm` for `iOS`-specific builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,12 @@ if(APPLE)
         set(SDLIMAGE_IMAGEIO_ENABLED TRUE)
         if(CMAKE_SYSTEM_NAME MATCHES ".*(Darwin|MacOS).*")
             target_link_libraries(${sdl3_image_target_name} PRIVATE -Wl,-framework,ApplicationServices)
+        elseif(IOS)
+            target_link_libraries(${sdl3_image_target_name} PRIVATE
+                -Wl,-framework,CoreGraphics
+                -Wl,-framework,ImageIO
+                -Wl,-framework,MobileCoreServices
+            )
         endif()
         target_link_libraries(${sdl3_image_target_name} PRIVATE objc)
         target_sources(${sdl3_image_target_name} PRIVATE


### PR DESCRIPTION
The `ApplicationServices` framework, which includes `ImageIO`-specific definitions, is not available on `iOS`. It was removed in [Issue 470](https://github.com/libsdl-org/SDL_image/issues/470), and no replacement is currently linked for `iOS` builds.

As a result, without linking the appropriate `iOS` frameworks, the [`ImageIO`](https://developer.apple.com/documentation/imageio)  backend won't function on `iOS`.
However, [`ImageIO`](https://developer.apple.com/documentation/imageio) itself has been available on `iOS` since version `4.0`.

<img width="260" alt="Screenshot 2025-05-04 at 12 00 20" src="https://github.com/user-attachments/assets/7aeca442-20d1-4a7a-a7a9-74d1a1cf829e" />

A temporary workaround is to disable the `ImageIO` backend for `iOS` builds, although there don’t appear to be any technical reasons preventing its use:

```cmake
set(SDL2IMAGE_BACKEND_IMAGEIO OFF)
```

To enable `ImageIO` support on `iOS`, the build should link against the following frameworks:

* `Core Graphics` - for `CGContext` calls like `CGBitmapContextCreate`
* `ImageIO` - for `CGImageSource` functions such as `CGImageSourceCreateImageAtIndex`
* `MobileCoreServices` - for definitions like `UTTypeGIF`