### PR TITLE
IMG.c: Loader now keeps trying other formats, if other supported format(s) failed to load an image

### DIFF
--- a/src/IMG_ImageIO.m
+++ b/src/IMG_ImageIO.m
@@ -365,12 +365,7 @@ static bool Internal_isType (SDL_IOStream *rw_ops, CFStringRef uti_string_to_tes
     }
 
     Sint64 start = SDL_TellIO(rw_ops);
-    CFDictionaryRef hint_dictionary = CreateHintDictionary(uti_string_to_test);
-    CGImageSourceRef image_source = CreateCGImageSourceFromIOStream(rw_ops, hint_dictionary);
-
-    if (hint_dictionary != NULL) {
-        CFRelease(hint_dictionary);
-    }
+    CGImageSourceRef image_source = CreateCGImageSourceFromIOStream(rw_ops, NULL);
 
     if (NULL == image_source) {
         // reset the file pointer


### PR DESCRIPTION
Hi

This PR makes IMG.c keep trying to load an image if another format fails.

The reason I even had this problem comes from trying to load [this](https://limewire.com/d/MjcEJ#YABhdMq1F8) WebP image on iOS (I could not attach it to PR as GitHub does not support this format)

For some reason, this image was recognized as a TIF format image by the `UTTypeConformsTo`. I tried replacing it with the `UTTypeEqual`, but got the same result. The image load was failing because the TIF format check was performed before checking against WEBP.

While the problem I had is likely some rare edge case, I believe it would still be a good thing to try to handle such rare hiccups.