### PR TITLE
improve INTRO-visualstudio.md with more detailed Visual Studio steps

### DIFF
--- a/docs/INTRO-visualstudio.md
+++ b/docs/INTRO-visualstudio.md
@@ -9,6 +9,8 @@ We'll start by creating a simple project to build and run [hello.c](hello.c)
 - Add hello.c to the Source Files
 - Right click the solution, select add an existing project, navigate to the SDL VisualC/SDL directory and add SDL.vcxproj
 - Right click the solution, select add an existing project, navigate to the SDL_image VisualC directory and add SDL_image.vcxproj
+- Select your SDL_image project and go to Project -> Add Reference and select SDL3
+- Select your SDL_image project and go to Project -> Properties, set the filter at the top to "All Configurations" and "All Platforms", select VC++ Directories and modify the default SDL path in "Include Directories" to point to your SDL include directories
 - Select your main project and go to Project -> Add Reference and select SDL3 and SDL3_image
 - Select your main project and go to Project -> Properties, set the filter at the top to "All Configurations" and "All Platforms", select VC++ Directories and add the SDL and SDL_image include directories to "Include Directories"
 - Build and run!


### PR DESCRIPTION
The original guide was missing the steps for adding the SDL3 include directories and the SDL3 reference in the SDL3_image project. I have added these steps.