### PR TITLE
Improve palette handling in STB backend

### DIFF
--- a/src/IMG_stb.c
+++ b/src/IMG_stb.c
@@ -191,6 +191,8 @@ SDL_Surface *IMG_LoadSTB_RW(SDL_RWops *src)
                 SDL_FreeSurface(surface);
                 surface = converted;
             } else if (has_colorkey) {
+                /* remove redundant pixel alpha before setting colorkey */
+                palette->colors[colorkey_index].a = SDL_ALPHA_OPAQUE;
                 SDL_SetColorKey(surface, SDL_TRUE, colorkey_index);
             }
         }


### PR DESCRIPTION
fixes https://github.com/libsdl-org/sdl2-compat/issues/492

While I was investigating that issue I realised that this must actually be fixed on the `SDL_image` end and not `sdl2-compat` end as I initially assumed.

This PR makes the stbimage backend path more like the libpng backend:
- If a colorkey is set along with a palette, the colorkey entry shouldn't have redundant pixel alpha of 0 as that messes up the `SDL_MapRGB` logic.
- The stbimage backend always gives 256 entries in the palette, even if less entries are required. It seems like stb image does not expose this information in its API. I have put a bit of a hacky solution to this issue. It's certainly not very efficient but is the easiest approach I could think of.