### PR TITLE
Save non-alpha pngs as RGB not RGBA, handle arbitrary surface pitch properly (miniz backend)

### DIFF
--- a/src/IMG_png.c
+++ b/src/IMG_png.c
@@ -812,8 +812,7 @@ static int IMG_SavePNG_RW_miniz(SDL_Surface *surface, SDL_RWops *dst)
                 png = tdefl_write_image_to_png_file_in_memory(tightened_pixels, w, h, bpp, tightened_pitch, &size);
                 SDL_free(tightened_pixels);
             }
-        }
-        else {
+        } else {
             png = tdefl_write_image_to_png_file_in_memory(pixels, w, h, bpp, pitch, &size);
         }
     }


### PR DESCRIPTION
This PR is an attempt to make the behaviour of SavePNG more consistent across backends (miniz and libpng). With this PR, images that don't need alpha will now be stored as RGB instead of RGBA.