### PR TITLE
fix unused paramater warnings

### DIFF
--- a/src/IMG_avif.c
+++ b/src/IMG_avif.c
@@ -707,10 +707,6 @@ done:
 /* We don't have any way to save AVIF files */
 #undef SDL_IMAGE_SAVE_AVIF
 
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
-
 /* See if an image is contained in a data source */
 bool IMG_isAVIF(SDL_IOStream *src)
 {

--- a/src/IMG_bmp.c
+++ b/src/IMG_bmp.c
@@ -473,41 +473,43 @@ SDL_Surface *IMG_LoadCUR_IO(SDL_IOStream *src)
 
 #else
 
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
-
 /* See if an image is contained in a data source */
 bool IMG_isBMP(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
 
 bool IMG_isICO(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
 
 bool IMG_isCUR(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
 
 /* Load a BMP type image from an SDL datasource */
 SDL_Surface *IMG_LoadBMP_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 
 /* Load a BMP type image from an SDL datasource */
 SDL_Surface *IMG_LoadCUR_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 
 /* Load a BMP type image from an SDL datasource */
 SDL_Surface *IMG_LoadICO_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 

--- a/src/IMG_gif.c
+++ b/src/IMG_gif.c
@@ -742,6 +742,7 @@ IMG_Animation *IMG_LoadGIFAnimation_IO(SDL_IOStream *src)
 /* Load a GIF type animation from an SDL datasource */
 IMG_Animation *IMG_LoadGIFAnimation_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 
@@ -789,19 +790,18 @@ SDL_Surface *IMG_LoadGIF_IO(SDL_IOStream *src)
 }
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isGIF(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
 
 /* Load a GIF type image from an SDL datasource */
 SDL_Surface *IMG_LoadGIF_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 

--- a/src/IMG_jpg.c
+++ b/src/IMG_jpg.c
@@ -663,9 +663,6 @@ SDL_Surface *IMG_LoadJPG_IO(SDL_IOStream *src)
 #endif /* WANT_JPEGLIB */
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isJPG(SDL_IOStream *src)

--- a/src/IMG_jxl.c
+++ b/src/IMG_jxl.c
@@ -251,9 +251,6 @@ done:
 }
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isJXL(SDL_IOStream *src)

--- a/src/IMG_lbm.c
+++ b/src/IMG_lbm.c
@@ -503,19 +503,18 @@ done:
 }
 
 #else /* LOAD_LBM */
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isLBM(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
 
 /* Load an IFF type image from an SDL datasource */
 SDL_Surface *IMG_LoadLBM_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 

--- a/src/IMG_pcx.c
+++ b/src/IMG_pcx.c
@@ -293,19 +293,18 @@ done:
 }
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isPCX(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
 
 /* Load a PCX type image from an SDL datasource */
 SDL_Surface *IMG_LoadPCX_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 

--- a/src/IMG_png.c
+++ b/src/IMG_png.c
@@ -543,19 +543,18 @@ SDL_Surface *IMG_LoadPNG_IO(SDL_IOStream *src)
 #endif /* WANT_LIBPNG */
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isPNG(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
 
 /* Load a PNG type image from an SDL datasource */
 SDL_Surface *IMG_LoadPNG_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 

--- a/src/IMG_pnm.c
+++ b/src/IMG_pnm.c
@@ -253,19 +253,18 @@ done:
 }
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isPNM(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
 
 /* Load a PNM type image from an SDL datasource */
 SDL_Surface *IMG_LoadPNM_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 

--- a/src/IMG_qoi.c
+++ b/src/IMG_qoi.c
@@ -108,19 +108,18 @@ SDL_Surface *IMG_LoadQOI_IO(SDL_IOStream *src)
 }
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isQOI(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
 
 /* Load a QOI type image from an SDL datasource */
 SDL_Surface *IMG_LoadQOI_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 

--- a/src/IMG_svg.c
+++ b/src/IMG_svg.c
@@ -160,19 +160,20 @@ SDL_Surface *IMG_LoadSizedSVG_IO(SDL_IOStream *src, int width, int height)
 }
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isSVG(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
 
 /* Load a SVG type image from an SDL datasource */
 SDL_Surface *IMG_LoadSizedSVG_IO(SDL_IOStream *src, int width, int height)
 {
+    (void)src;
+    (void)width;
+    (void)height;
     return NULL;
 }
 

--- a/src/IMG_tga.c
+++ b/src/IMG_tga.c
@@ -336,14 +336,12 @@ error:
 }
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* dummy TGA load routine */
 SDL_Surface *IMG_LoadTGA_IO(SDL_IOStream *src)
 {
-    return(NULL);
+    (void)src;
+    return NULL;
 }
 
 #endif /* LOAD_TGA */

--- a/src/IMG_tif.c
+++ b/src/IMG_tif.c
@@ -218,15 +218,11 @@ error:
 }
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isTIF(SDL_IOStream *src)
 {
     (void)src;
-
     return false;
 }
 
@@ -234,7 +230,6 @@ bool IMG_isTIF(SDL_IOStream *src)
 SDL_Surface *IMG_LoadTIF_IO(SDL_IOStream *src)
 {
     (void)src;
-
     return NULL;
 }
 

--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -429,15 +429,11 @@ error:
 }
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isWEBP(SDL_IOStream *src)
 {
     (void)src;
-
     return false;
 }
 
@@ -445,14 +441,12 @@ bool IMG_isWEBP(SDL_IOStream *src)
 SDL_Surface *IMG_LoadWEBP_IO(SDL_IOStream *src)
 {
     (void)src;
-
     return NULL;
 }
 
 IMG_Animation *IMG_LoadWEBPAnimation_IO(SDL_IOStream *src)
 {
     (void)src;
-
     return NULL;
 }
 

--- a/src/IMG_xcf.c
+++ b/src/IMG_xcf.c
@@ -1029,19 +1029,18 @@ done:
 }
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isXCF(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
 
 /* Load a XCF type image from an SDL datasource */
 SDL_Surface *IMG_LoadXCF_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 

--- a/src/IMG_xpm.c
+++ b/src/IMG_xpm.c
@@ -1208,30 +1208,30 @@ SDL_Surface *IMG_ReadXPMFromArrayToRGB888(char **xpm)
 }
 
 #else  /* not LOAD_XPM */
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isXPM(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
-
 
 /* Load a XPM type image from an SDL datasource */
 SDL_Surface *IMG_LoadXPM_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 
 SDL_Surface *IMG_ReadXPMFromArray(char **xpm)
 {
+    (void)xpm;
     return NULL;
 }
 
 SDL_Surface *IMG_ReadXPMFromArrayToRGB888(char **xpm)
 {
+    (void)xpm;
     return NULL;
 }
 

--- a/src/IMG_xv.c
+++ b/src/IMG_xv.c
@@ -148,19 +148,18 @@ done:
 }
 
 #else
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
 
 /* See if an image is contained in a data source */
 bool IMG_isXV(SDL_IOStream *src)
 {
+    (void)src;
     return false;
 }
 
 /* Load a XXX type image from an SDL datasource */
 SDL_Surface *IMG_LoadXV_IO(SDL_IOStream *src)
 {
+    (void)src;
     return NULL;
 }
 

--- a/src/IMG_xxx.c
+++ b/src/IMG_xxx.c
@@ -76,19 +76,15 @@ SDL_Surface *IMG_LoadXXX_IO(SDL_IOStream *src)
 
 #else
 
-#if defined(_MSC_VER) && _MSC_VER >= 1300
-#pragma warning(disable : 4100) /* warning C4100: 'op' : unreferenced formal parameter */
-#endif
-
 bool IMG_isXXX(SDL_IOStream *src)
 {
-    (void) src;
+    (void)src;
     return false;
 }
 
 SDL_Surface *IMG_LoadXXX_IO(SDL_IOStream *src)
 {
-    (void) src;
+    (void)src;
     return NULL;
 }
 


### PR DESCRIPTION
Currently, when various backends are disabled, GCC and clang spit out a large number of warnings due to unused parameters. The code already uses a pragma to disable these warnings on MSVC (mostly), but not other compilers, as well occasionally using void statements to silence individual cases.

This PR just standardises things by always using void statements to silence the warnings, which works with all compilers and removes the need for any pragmas.