### PR TITLE
docs: improve INTRO-cmake.md

### DIFF
--- a/docs/INTRO-cmake.md
+++ b/docs/INTRO-cmake.md
@@ -5,6 +5,13 @@ The easiest way to use SDL_image is to include it along with SDL as subprojects 
 
 We'll start by creating a simple project to build and run [hello.c](hello.c)
 
+Get a copy of the SDL and SDL_image source:
+
+```sh
+git clone https://github.com/libsdl-org/SDL.git vendored/SDL
+git clone https://github.com/libsdl-org/SDL_image.git vendored/SDL_image
+```
+
 Create the file CMakeLists.txt
 ```cmake
 cmake_minimum_required(VERSION 3.16)


### PR DESCRIPTION
## Background

When going through the SDL_image [CMake](https://github.com/libsdl-org/SDL_image/blob/main/docs/INTRO-cmake.md) installation instructions, the user will run into some problems.

1. There's no step for cloning the `SDL_image` git repository into the `vendored` directory.
2. `"vendored/SDL"` is also required and referenced in the `CMakeLists.txt` file. Arguably cloning the `SDL` git repository should also be included in the instructions.

## Changes

- Added steps for cloning the `SDL` and `SDL_image` repositories into the `vendored` directory

## Comments

This change will also align this file with the SDL repository [INTRO-cmake.md](https://github.com/libsdl-org/SDL/blob/main/docs/INTRO-cmake.md) which includes the git clone steps.