### PR TITLE
Update IMG_webp.c

### DIFF
--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -221,7 +221,7 @@ SDL_Surface *IMG_LoadWEBP_IO(SDL_IOStream *src)
 
     // Special casing for animated WebP images to extract a single frame.
     if (features.has_animation) {
-        if (SDL_SeekIO(src, start, SDL_IO_SEEK_SET) != 0) {
+        if (SDL_SeekIO(src, start, SDL_IO_SEEK_SET) < 0) {
             error = "Failed to seek IO to read animated WebP";
             goto error;
         } else {

--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -357,7 +357,7 @@ static IMG_Animation *IMG_LoadWEBPAnimation_IO_Internal(SDL_IOStream *src, int m
     anim->w = features.width;
     anim->h = features.height;
     uint32_t fc = lib.WebPDemuxGetI(demuxer, WEBP_FF_FRAME_COUNT);
-    anim->count = maxFrames > 0 ? SDL_min(maxFrames, fc) : fc;
+    anim->count = maxFrames > 0 ? SDL_min((unsigned)maxFrames, fc) : fc;
     anim->frames = (SDL_Surface **)SDL_calloc(anim->count, sizeof(*anim->frames));
     anim->delays = (int *)SDL_calloc(anim->count, sizeof(*anim->delays));
     if (!anim->frames || !anim->delays) {
@@ -387,10 +387,9 @@ static IMG_Animation *IMG_LoadWEBPAnimation_IO_Internal(SDL_IOStream *src, int m
 
     SDL_zero(iter);
 
-    int frame_idx = 0;
     if (lib.WebPDemuxGetFrame(demuxer, 1, &iter)) {
         do {
-            frame_idx = (iter.frame_num - 1);
+            int frame_idx = (iter.frame_num - 1);
             if (frame_idx < 0 || frame_idx >= anim->count) {
                 continue;
             }
@@ -427,7 +426,7 @@ static IMG_Animation *IMG_LoadWEBPAnimation_IO_Internal(SDL_IOStream *src, int m
             anim->delays[frame_idx] = iter.duration;
             dispose_method = iter.dispose_method;
 
-        } while ((maxFrames > 0 ? frame_idx + 1 < maxFrames : true) && lib.WebPDemuxNextFrame(&iter));
+        } while (lib.WebPDemuxNextFrame(&iter));
 
         lib.WebPDemuxReleaseIterator(&iter);
     }

--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -316,10 +316,6 @@ IMG_Animation *IMG_LoadWEBPAnimation_IO_Internal(SDL_IOStream *src, int maxFrame
         return NULL;
     }
 
-    if (maxFrames < 0) {
-        maxFrames = 0; /* no limit */
-    }
-
     start = SDL_TellIO(src);
 
     if (!IMG_InitWEBP()) {

--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -166,7 +166,7 @@ bool IMG_isWEBP(SDL_IOStream *src)
     return webp_getinfo(src, NULL);
 }
 
-IMG_Animation *IMG_LoadWEBPAnimation_IO_Internal(SDL_IOStream *src, int maxFrames);
+static IMG_Animation *IMG_LoadWEBPAnimation_IO_Internal(SDL_IOStream *src, int maxFrames);
 
 SDL_Surface *IMG_LoadWEBP_IO(SDL_IOStream *src)
 {

--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -221,7 +221,7 @@ SDL_Surface *IMG_LoadWEBP_IO(SDL_IOStream *src)
 
     // Special casing for animated WebP images to extract a single frame.
     if (features.has_animation) {
-        if (SDL_SeekIO(src, 0, SDL_IO_SEEK_SET) != 0) {
+        if (SDL_SeekIO(src, start, SDL_IO_SEEK_SET) != 0) {
             error = "Failed to seek IO to read animated WebP";
             goto error;
         } else {

--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -296,7 +296,7 @@ error:
     return NULL;
 }
 
-IMG_Animation *IMG_LoadWEBPAnimation_IO_Internal(SDL_IOStream *src, int maxFrames)
+static IMG_Animation *IMG_LoadWEBPAnimation_IO_Internal(SDL_IOStream *src, int maxFrames)
 {
     Sint64 start;
     const char *error = NULL;

--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -233,6 +233,7 @@ SDL_Surface *IMG_LoadWEBP_IO(SDL_IOStream *src)
                     if (raw_data) {
                         SDL_free(raw_data);
                     }
+                    IMG_FreeAnimation(animation);
                     return surf;
                 } else {
                     error = "Failed to load first frame of animated WebP";


### PR DESCRIPTION
## What it does?
Fix API inconsistency with allowing animated WebP images to be used with IMG_LoadWEBP_IO to extract a single frame, just like GIF.

This basically calls IMG_LoadWEBPAnimation_IO to get the frame list, then extracts the first frame to return within IMG_LoadWEBP_IO, evaluating to API consistency with how SDL handles GIF images with IMG_Load.

Some additions, like combining the pre-defined error code with the error code from SDL_BlitSurface, might be added if necessary.
Please ask me to make changes if required.


## What was the Issue?
This resolves https://github.com/libsdl-org/SDL_image/issues/570 directly with the suggested changes.