### PR TITLE
Seek stream to the beginning if error in IMG_SaveWEBP_IO

### DIFF
--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -531,7 +531,7 @@ bool IMG_SaveWEBP_IO(SDL_Surface *surface, SDL_IOStream *dst, bool closeio, floa
     bool pic_initialized = false;
     bool memorywriter_initialized = false;
     bool converted_surface_locked = false;
-    Sint64 start;
+    Sint64 start = -1;
 
     if (!surface || !dst) {
         error = "Invalid input surface or destination stream.";
@@ -638,7 +638,7 @@ cleanup:
     }
 
     if (error) {
-        if (!closeio) {
+        if (!closeio && start != -1) {
             SDL_SeekIO(dst, start, SDL_IO_SEEK_SET);
         }
         SDL_SetError("%s", error);

--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -531,11 +531,14 @@ bool IMG_SaveWEBP_IO(SDL_Surface *surface, SDL_IOStream *dst, bool closeio, floa
     bool pic_initialized = false;
     bool memorywriter_initialized = false;
     bool converted_surface_locked = false;
+    Sint64 start;
 
     if (!surface || !dst) {
         error = "Invalid input surface or destination stream.";
         goto cleanup;
     }
+
+    start = SDL_TellIO(dst);
 
     if (!IMG_InitWEBP()) {
         error = SDL_GetError();
@@ -635,6 +638,9 @@ cleanup:
     }
 
     if (error) {
+        if (!closeio) {
+            SDL_SeekIO(dst, start, SDL_IO_SEEK_SET);
+        }
         SDL_SetError("%s", error);
         ret = false;
     }


### PR DESCRIPTION
IMG_LoadWEBP_IO and IMG_LoadWEBPAnimation_IO_Internal get the position at the beginning and set it back to the stream if the operation fails. Following this standard, the same was added to our new save function, so it behaves the same.