### PR TITLE
Destroy image if NormalizeFrames fails in GIF Animation

### DIFF
--- a/src/IMG_gif.c
+++ b/src/IMG_gif.c
@@ -188,6 +188,7 @@ static bool NormalizeFrames(Frame_t *frames, int count)
         SDL_DestroySurface(frames[i].image);
         frames[i].image = SDL_DuplicateSurface(image);
         if (!frames[i].image) {
+            SDL_DestroySurface( image );
             return false;
         }
 


### PR DESCRIPTION
Destroys the created image surface if NormalizeFrames fails so we don't silently leak memory.

This fixes #583 