### PR TITLE
Encode & Decode AVIF Animation Support (AVIFS)

### DIFF
--- a/VisualC/SDL_image.vcxproj
+++ b/VisualC/SDL_image.vcxproj
@@ -227,6 +227,7 @@
     <ClInclude Include="..\include\SDL3_image\SDL_image.h" />
     <ClInclude Include="..\src\IMG_libpng.h" />
     <ClInclude Include="..\src\IMG_gif.h" />
+    <ClInclude Include="..\src\IMG_avif.h" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="external\optional\x64\libavif-16.dll">
@@ -434,4 +435,5 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>
+
 

--- a/VisualC/SDL_image.vcxproj.filters
+++ b/VisualC/SDL_image.vcxproj.filters
@@ -92,6 +92,9 @@
     <ClInclude Include="..\src\IMG_gif.h">
       <Filter>Sources</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\IMG_avif.h">
+      <Filter>Sources</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\src\version.rc">
@@ -168,6 +171,7 @@
   </ItemGroup>
 
 </Project>
+
 
 
 

--- a/src/IMG.c
+++ b/src/IMG.c
@@ -82,6 +82,7 @@ static struct {
     { "GIF", IMG_isGIF, IMG_LoadGIFAnimation_IO     },
     { "WEBP", IMG_isWEBP, IMG_LoadWEBPAnimation_IO  },
     { "APNG", IMG_isPNG, IMG_LoadAPNGAnimation_IO   },
+    { "AVIFS", IMG_isAVIF, IMG_LoadAVIFAnimation_IO },
 };
 
 int IMG_Version(void)

--- a/src/IMG_anim.c
+++ b/src/IMG_anim.c
@@ -25,6 +25,7 @@
 #include "IMG_webp.h"
 #include "IMG_libpng.h"
 #include "IMG_gif.h"
+#include "IMG_avif.h"
 
 IMG_AnimationStream *IMG_CreateAnimationStream(const char *file)
 {
@@ -139,6 +140,8 @@ IMG_AnimationStream *IMG_CreateAnimationStreamWithProperties(SDL_PropertiesID pr
         result = IMG_CreateAPNGAnimationStream(stream, props);
     } else if (SDL_strcasecmp(type, "gif") == 0) {
         result = IMG_CreateGIFAnimationStream(stream, props);
+    } else if (SDL_strcasecmp(type, "avifs") == 0) {
+        result = IMG_CreateAVIFAnimationStream(stream, props);
     } else {
         SDL_SetError("Unrecognized output type");
     }

--- a/src/IMG_avif.h
+++ b/src/IMG_avif.h
@@ -1,0 +1,23 @@
+/*
+  SDL_image:  An example image loading library for use with SDL
+  Copyright (C) 1997-2025 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+extern bool IMG_CreateAVIFAnimationStream(IMG_AnimationStream *stream, SDL_PropertiesID props);
+


### PR DESCRIPTION
## Introducing AVIF Animation Decoding and Encoding Support (aka AVIFS)
Implements `IMG_CreateAVIFAnimationStream` for encoding and `IMG_LoadAVIFAnimation_IO` for decoding `AVIFS` files similar to `WEBP`, `GIF`, and `APNG` support.

_**Please note that the AVIFS encoding/decoding does not modify the existing AVIF code and only adds this new support on top of it.**_

### Current Features
- Exposes `maxthreads` through the supplied `SDL_PropertiesID` so users can pick between 1 and the max available logical CPU cores for encoding.
- Exposes `keyframeinterval` through the supplied `SDL_PropertiesID` so users can decide between 1 and the desired value for lossless, and between 0 and the desired value for lossy encodings. Please note that for lossy encoding, it currently does not set the keyframe and only enforces a keyframe interval to be 1 or above for lossless encoding. When lossy is picked and the keyframe is set to 0, you may see dirty region artifacts; this is usually due to AVIF's internal encoding. To prevent this, use lossless encoding where possible, or just keyframe to 1.
- Support for 16-bit images (`SDL_PIXELFORMAT_RGB48`, `SDL_PIXELFORMAT_BGR48`, `SDL_PIXELFORMAT_RGBA64`, `SDL_PIXELFORMAT_ARGB64`, `SDL_PIXELFORMAT_BGRA64`, and `SDL_PIXELFORMAT_ABGR64`) in both encoder and decoder.
- Support for 10-bit images (`SDL_ISPIXELFORMAT_10BIT`) in both encoder and decoder.
- Support for HDR with the `SetHDRProperties` helper function in both encoder and decoder. Respects `SDL_PROP_SURFACE_MAXCLL_NUMBER`, `SDL_PROP_SURFACE_MAXFALL_NUMBER`, `SDL_PROP_SURFACE_SDR_WHITE_POINT_FLOAT`, and `SDL_PROP_SURFACE_HDR_HEADROOM_FLOAT`.
- Support for SDR (8-bit) images (`RGB`, `BGR`, `RGBA`, and `BGRA`) in both encoder and decoder.
- Ignores the alpha channel if not present for efficiency in encoding/decoding.

This has been achieved using the existing libavif16 and the pre-existing encode/decode functions in the `lib` struct; nothing additional has been introduced.