### PR TITLE
Handle PNG_COLOR_TYPE_RGB with SDL_PIXELFORMAT_RGBA24

### DIFF
--- a/src/IMG_libpng.c
+++ b/src/IMG_libpng.c
@@ -443,6 +443,8 @@ static bool LIBPNG_LoadPNG_IO_Internal(SDL_IOStream *src, struct png_load_vars *
             lib.png_read_update_info(vars->png_ptr, vars->info_ptr);
             vars->format = SDL_PIXELFORMAT_RGBA32;
         }
+    } else if (vars->color_type == PNG_COLOR_TYPE_RGB) {
+        vars->format = SDL_PIXELFORMAT_RGB24;
     } else {
         vars->format = SDL_PIXELFORMAT_RGBA32;
     }

--- a/src/IMG_libpng.c
+++ b/src/IMG_libpng.c
@@ -420,7 +420,8 @@ static bool LIBPNG_LoadPNG_IO_Internal(SDL_IOStream *src, struct png_load_vars *
 
         if (lib.png_get_valid(vars->png_ptr, vars->info_ptr, PNG_INFO_tRNS)) {
             lib.png_set_tRNS_to_alpha(vars->png_ptr);
-        } else if (!(vars->color_type & PNG_COLOR_MASK_ALPHA)) {
+        } else if (vars->color_type != PNG_COLOR_TYPE_RGB && !(vars->color_type & PNG_COLOR_MASK_ALPHA)) {
+            // Only add filler for non-RGB formats that don't have alpha
             lib.png_set_filler(vars->png_ptr, 0xFF, PNG_FILLER_AFTER);
         }
     }


### PR DESCRIPTION
Support for handling `PNG_COLOR_TYPE_RGB` in `PNG` loading without `ALPHA` to be created with the `SDL_PIXELFORMAT_RGBA24` pixel format for efficiency.