### PR TITLE
Fix Octree Conditions in IMG_gif.c

### DIFF
--- a/src/IMG_gif.c
+++ b/src/IMG_gif.c
@@ -33,8 +33,8 @@
 #if SAVE_GIF
     #ifndef SAVE_GIF_OCTREE
         #define SAVE_GIF_OCTREE 1
-    #endif /* SAVE_GIF_OCTREE */
-#endif /* SAVE_GIF */
+    #endif
+#endif
 
 #ifdef LOAD_GIF
 
@@ -1159,7 +1159,7 @@ static int lzwCompress(const uint8_t *indexedPixels, uint16_t width, uint16_t he
 #if SAVE_GIF_OCTREE
 #ifndef OCTREE_MAX_LEVELS
     #define OCTREE_MAX_LEVELS 8
-#endif /* OCTREE_MAX_LEVELS */
+#endif
 
 typedef struct OctreeNode
 {


### PR DESCRIPTION
A small bug fix to change `defined(SAVE_GIF)` to `SAVE_GIF` so the value of `SAVE_GIF` is considered while defining `SAVE_GIF_OCTREE`.