### PR TITLE
IMG_avif.c: Fix garbage value read

### DIFF
--- a/src/IMG_avif.c
+++ b/src/IMG_avif.c
@@ -544,6 +544,7 @@ static bool IMG_SaveAVIF_IO_libavif(SDL_Surface *surface, SDL_IOStream *dst, int
     maxCLL = (Uint16)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_MAXCLL_NUMBER, 0);
     maxFALL = (Uint16)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_MAXFALL_NUMBER, 0);
 
+    SDL_zero(rgb);
     image = lib.avifImageCreate(surface->w, surface->h, 10, AVIF_PIXEL_FORMAT_YUV444);
     if (!image) {
         SDL_SetError("Couldn't create AVIF YUV image");
@@ -555,7 +556,6 @@ static bool IMG_SaveAVIF_IO_libavif(SDL_Surface *surface, SDL_IOStream *dst, int
     image->clli.maxCLL = maxCLL;
     image->clli.maxPALL = maxFALL;
 
-    SDL_zero(rgb);
     lib.avifRGBImageSetDefaults(&rgb, image);
 
     if (SDL_ISPIXELFORMAT_10BIT(surface->format)) {


### PR DESCRIPTION
```c
[ 13%] Building C object CMakeFiles/SDL3_image-shared.dir/src/IMG_avif.c.o
/path/to/SDL_image/src/IMG_avif.c:692:9: warning: Branch condition evaluates to a garbage value [clang-analyzer-core.uninitialized.Branch]
  692 |     if (rgb.pixels) {
      |         ^~~~~~~~~~
/path/to/SDL_image/src/IMG_avif.c:537:5: note: Taking false branch
  537 |     if (!IMG_InitAVIF()) {
      |     ^
/path/to/SDL_image/src/IMG_avif.c:548:9: note: Assuming 'image' is null
  548 |     if (!image) {
      |         ^~~~~~
/path/to/SDL_image/src/IMG_avif.c:548:5: note: Taking true branch
  548 |     if (!image) {
      |     ^
/path/to/SDL_image/src/IMG_avif.c:550:9: note: Control jumps to line 692
  550 |         goto done;
      |         ^
/path/to/SDL_image/src/IMG_avif.c:692:9: note: Branch condition evaluates to a garbage value
  692 |     if (rgb.pixels) {
      |         ^~~~~~~~~~
```