### PR TITLE
src/IMG_xcf.c:read_xcf_level(): return NULL when read fails

### DIFF
--- a/src/IMG_xcf.c
+++ b/src/IMG_xcf.c
@@ -577,6 +577,7 @@ static xcf_level *read_xcf_level(SDL_IOStream *src, const xcf_header *h)
     if (!SDL_ReadU32BE (src, &l->width) ||
         !SDL_ReadU32BE (src, &l->height)) {
         free_xcf_level(l);
+        return NULL;
     }
 
     i = 0;


### PR DESCRIPTION
In file `src/IMG_xcf.c`, in function `read_xcf_level()`: When reading fails, the `xcf_level *` varible `l` gets freed but the function does not return and continues using the variable.

<details><summary>Warning</summary>
<p>

```c
[ 65%] Building C object CMakeFiles/SDL3_image-shared.dir/src/IMG_xcf.c.o
/path/to/SDL_image/src/IMG_xcf.c:584:54: warning: Use of memory after it is freed [clang-analyzer-unix.Malloc]
  584 |         l->tile_file_offsets = (Uint64 *)SDL_realloc(l->tile_file_offsets, sizeof(*l->tile_file_offsets) * (i+1));
      |                                                      ^
/path/to/SDL_image/src/IMG_xcf.c:903:9: note: Assuming 'src' is non-null
  903 |     if (!src) {
      |         ^~~~
/path/to/SDL_image/src/IMG_xcf.c:903:5: note: Taking false branch
  903 |     if (!src) {
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:913:10: note: 'head' is non-null
  913 |     if (!head) {
      |          ^~~~
/path/to/SDL_image/src/IMG_xcf.c:913:5: note: Taking false branch
  913 |     if (!head) {
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:918:5: note: Control jumps to 'case COMPR_NONE:'  at line 919
  918 |     switch (head->compr) {
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:921:9: note:  Execution continues on line 931
  921 |         break;
      |         ^
/path/to/SDL_image/src/IMG_xcf.c:932:9: note: Assuming 'surface' is not equal to NULL
  932 |     if (surface == NULL) {
      |         ^~~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:932:5: note: Taking false branch
  932 |     if (surface == NULL) {
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:939:12: note: Assuming the condition is true
  939 |     while ((offset = read_offset(src, head)) != 0) {
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:939:5: note: Loop condition is true.  Entering loop body
  939 |     while ((offset = read_offset(src, head)) != 0) {
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:939:5: note: Loop condition is false. Execution continues on line 944
/path/to/SDL_image/src/IMG_xcf.c:947:9: note: Assuming 'lays' is not equal to NULL
  947 |     if (lays == NULL) {
      |         ^~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:947:5: note: Taking false branch
  947 |     if (lays == NULL) {
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:953:5: note: Loop condition is true.  Entering loop body
  953 |     for (i = offsets; i > 0; i--) {
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:958:13: note: 'layer' is not equal to NULL
  958 |         if (layer != NULL) {
      |             ^~~~~
/path/to/SDL_image/src/IMG_xcf.c:958:9: note: Taking true branch
  958 |         if (layer != NULL) {
      |         ^
/path/to/SDL_image/src/IMG_xcf.c:959:17: note: Assuming field 'visible' is not equal to 0
  959 |             if (layer->visible) {
      |                 ^~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:959:13: note: Taking true branch
  959 |             if (layer->visible) {
      |             ^
/path/to/SDL_image/src/IMG_xcf.c:960:17: note: Calling 'do_layer_surface'
  960 |                 do_layer_surface(lays, src, head, layer, load_tile);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:734:9: note: Assuming the condition is false
  734 |     if (SDL_SeekIO(src, layer->hierarchy_file_offset, SDL_IO_SEEK_SET) < 0) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:734:5: note: Taking false branch
  734 |     if (SDL_SeekIO(src, layer->hierarchy_file_offset, SDL_IO_SEEK_SET) < 0) {
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:739:9: note: Assuming field 'bpp' is <= 4
  739 |     if (hierarchy->bpp > 4) {  /* unsupported. */
      |         ^~~~~~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:739:5: note: Taking false branch
  739 |     if (hierarchy->bpp > 4) {  /* unsupported. */
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:745:10: note: Assuming field 'width' is <= 20000
  745 |     if ((hierarchy->width > 20000) || (hierarchy->height > 20000)) {  /* arbitrary limit to avoid integer overflow. */
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:745:9: note: Left side of '||' is false
  745 |     if ((hierarchy->width > 20000) || (hierarchy->height > 20000)) {  /* arbitrary limit to avoid integer overflow. */
      |         ^
/path/to/SDL_image/src/IMG_xcf.c:745:40: note: Assuming field 'height' is <= 20000
  745 |     if ((hierarchy->width > 20000) || (hierarchy->height > 20000)) {  /* arbitrary limit to avoid integer overflow. */
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:745:5: note: Taking false branch
  745 |     if ((hierarchy->width > 20000) || (hierarchy->height > 20000)) {  /* arbitrary limit to avoid integer overflow. */
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:752:5: note: Loop condition is true.  Entering loop body
  752 |     for (i = 0; hierarchy->level_file_offsets[i]; i++) {
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:753:13: note: Assuming the condition is false
  753 |         if (SDL_SeekIO(src, hierarchy->level_file_offsets[i], SDL_IO_SEEK_SET) < 0)
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:753:9: note: Taking false branch
  753 |         if (SDL_SeekIO(src, hierarchy->level_file_offsets[i], SDL_IO_SEEK_SET) < 0)
      |         ^
/path/to/SDL_image/src/IMG_xcf.c:755:13: note: 'i' is <= 0
  755 |         if (i > 0) /* skip level except the 1st one, just like GIMP does */
      |             ^
/path/to/SDL_image/src/IMG_xcf.c:755:9: note: Taking false branch
  755 |         if (i > 0) /* skip level except the 1st one, just like GIMP does */
      |         ^
/path/to/SDL_image/src/IMG_xcf.c:757:17: note: Calling 'read_xcf_level'
  757 |         level = read_xcf_level(src, head);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:573:22: note: Memory is allocated
  573 |     l = (xcf_level *)SDL_calloc(1, sizeof(xcf_level));
      |                      ^
/mnt/devel/dev/projects-NEW/external/libs/c/SDL/installs/SDL-git-Sackzement/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:5990:20: note: expanded from macro 'SDL_calloc'
 5990 | #define SDL_calloc calloc
      |                    ^
/path/to/SDL_image/src/IMG_xcf.c:574:9: note: Assuming 'l' is non-null
  574 |     if (!l) {
      |         ^~
/path/to/SDL_image/src/IMG_xcf.c:574:5: note: Taking false branch
  574 |     if (!l) {
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:577:9: note: Assuming the condition is true
  577 |     if (!SDL_ReadU32BE (src, &l->width) ||
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:577:41: note: Left side of '||' is true
  577 |     if (!SDL_ReadU32BE (src, &l->width) ||
      |                                         ^
/path/to/SDL_image/src/IMG_xcf.c:579:9: note: Calling 'free_xcf_level'
  579 |         free_xcf_level(l);
      |         ^~~~~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:562:9: note: 'l' is non-null
  562 |     if (l) {
      |         ^
/path/to/SDL_image/src/IMG_xcf.c:562:5: note: Taking true branch
  562 |     if (l) {
      |     ^
/path/to/SDL_image/src/IMG_xcf.c:564:9: note: Memory is released
  564 |         SDL_free(l);
      |         ^
/mnt/devel/dev/projects-NEW/external/libs/c/SDL/installs/SDL-git-Sackzement/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:5992:18: note: expanded from macro 'SDL_free'
 5992 | #define SDL_free free
      |                  ^
/path/to/SDL_image/src/IMG_xcf.c:579:9: note: Returning; memory was released via 1st parameter
  579 |         free_xcf_level(l);
      |         ^~~~~~~~~~~~~~~~~
/path/to/SDL_image/src/IMG_xcf.c:584:54: note: Use of memory after it is freed
  584 |         l->tile_file_offsets = (Uint64 *)SDL_realloc(l->tile_file_offsets, sizeof(*l->tile_file_offsets) * (i+1));
      |                                                      ^~~~~~~~~~~~~~~~~~~~
```

</p>
</details> 