### PR TITLE
showanim.c: Fix memory leak

### DIFF
--- a/examples/showanim.c
+++ b/examples/showanim.c
@@ -218,6 +218,7 @@ int main(int argc, char *argv[])
         for (j = 0; j < anim->count; ++j) {
             SDL_DestroyTexture(textures[j]);
         }
+        SDL_free(textures);
         IMG_FreeAnimation(anim);
     }
 


### PR DESCRIPTION
In the example `showanim.c` individual textures are destroyed but the memory block `textures` is not freed.

<details><summary>Warning</summary>
<p>

```c
[ 82%] Building C object CMakeFiles/showanim.dir/examples/showanim.c.o
/path/to/SDL_image/examples/showanim.c:224:5: warning: Potential leak of memory pointed to by 'textures' [clang-analyzer-unix.Malloc]
  224 |     SDL_DestroyRenderer(renderer);
      |     ^
/path/to/SDL_image/examples/showanim.c:89:10: note: Assuming the condition is false
   89 |     if ( ! argv[1] ) {
      |          ^~~~~~~~~
/path/to/SDL_image/examples/showanim.c:89:5: note: Taking false branch
   89 |     if ( ! argv[1] ) {
      |     ^
/path/to/SDL_image/examples/showanim.c:95:5: note: Loop condition is true.  Entering loop body
   95 |     for ( i=1; argv[i]; ++i ) {
      |     ^
/path/to/SDL_image/examples/showanim.c:96:14: note: Assuming the condition is false
   96 |         if ( SDL_strcmp(argv[i], "-fullscreen") == 0 ) {
      |              ^
/mnt/devel/dev/projects-NEW/external/libs/c/SDL/installs/SDL-git-Sackzement/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:6016:20: note: expanded from macro 'SDL_strcmp'
 6016 | #define SDL_strcmp strcmp
      |                    ^
/path/to/SDL_image/examples/showanim.c:96:9: note: Taking false branch
   96 |         if ( SDL_strcmp(argv[i], "-fullscreen") == 0 ) {
      |         ^
/path/to/SDL_image/examples/showanim.c:95:5: note: Loop condition is false. Execution continues on line 102
   95 |     for ( i=1; argv[i]; ++i ) {
      |     ^
/path/to/SDL_image/examples/showanim.c:102:9: note: Assuming the condition is false
  102 |     if (!SDL_Init(SDL_INIT_VIDEO)) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_image/examples/showanim.c:102:5: note: Taking false branch
  102 |     if (!SDL_Init(SDL_INIT_VIDEO)) {
      |     ^
/path/to/SDL_image/examples/showanim.c:107:9: note: Assuming the condition is false
  107 |     if (!SDL_CreateWindowAndRenderer("animation demo", 0, 0, flags, &window, &renderer)) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_image/examples/showanim.c:107:5: note: Taking false branch
  107 |     if (!SDL_CreateWindowAndRenderer("animation demo", 0, 0, flags, &window, &renderer)) {
      |     ^
/path/to/SDL_image/examples/showanim.c:112:5: note: Loop condition is true.  Entering loop body
  112 |     for ( i=1; argv[i]; ++i ) {
      |     ^
/path/to/SDL_image/examples/showanim.c:113:14: note: Assuming the condition is false
  113 |         if ( SDL_strcmp(argv[i], "-fullscreen") == 0 ) {
      |              ^
/mnt/devel/dev/projects-NEW/external/libs/c/SDL/installs/SDL-git-Sackzement/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:6016:20: note: expanded from macro 'SDL_strcmp'
 6016 | #define SDL_strcmp strcmp
      |                    ^
/path/to/SDL_image/examples/showanim.c:113:9: note: Taking false branch
  113 |         if ( SDL_strcmp(argv[i], "-fullscreen") == 0 ) {
      |         ^
/path/to/SDL_image/examples/showanim.c:117:14: note: Assuming the condition is false
  117 |         if ( SDL_strcmp(argv[i], "-once") == 0 ) {
      |              ^
/mnt/devel/dev/projects-NEW/external/libs/c/SDL/installs/SDL-git-Sackzement/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:6016:20: note: expanded from macro 'SDL_strcmp'
 6016 | #define SDL_strcmp strcmp
      |                    ^
/path/to/SDL_image/examples/showanim.c:117:9: note: Taking false branch
  117 |         if ( SDL_strcmp(argv[i], "-once") == 0 ) {
      |         ^
/path/to/SDL_image/examples/showanim.c:122:13: note: Assuming the condition is false
  122 |         if (SDL_strcmp(argv[i], "-save") == 0 && argv[i + 1]) {
      |             ^
/mnt/devel/dev/projects-NEW/external/libs/c/SDL/installs/SDL-git-Sackzement/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:6016:20: note: expanded from macro 'SDL_strcmp'
 6016 | #define SDL_strcmp strcmp
      |                    ^
/path/to/SDL_image/examples/showanim.c:122:47: note: Left side of '&&' is false
  122 |         if (SDL_strcmp(argv[i], "-save") == 0 && argv[i + 1]) {
      |                                               ^
/path/to/SDL_image/examples/showanim.c:130:13: note: Assuming 'anim' is non-null
  130 |         if (!anim) {
      |             ^~~~~
/path/to/SDL_image/examples/showanim.c:130:9: note: Taking false branch
  130 |         if (!anim) {
      |         ^
/path/to/SDL_image/examples/showanim.c:137:13: note: 'saveFile' is null
  137 |         if (saveFile) {
      |             ^~~~~~~~
/path/to/SDL_image/examples/showanim.c:137:9: note: Taking false branch
  137 |         if (saveFile) {
      |         ^
/path/to/SDL_image/examples/showanim.c:141:36: note: Memory is allocated
  141 |         textures = (SDL_Texture **)SDL_calloc(anim->count, sizeof(*textures));
      |                                    ^
/mnt/devel/dev/projects-NEW/external/libs/c/SDL/installs/SDL-git-Sackzement/Linux/Linux/gcc/Debug/include/SDL3/SDL_stdinc.h:5990:20: note: expanded from macro 'SDL_calloc'
 5990 | #define SDL_calloc calloc
      |                    ^
/path/to/SDL_image/examples/showanim.c:142:13: note: Assuming 'textures' is non-null
  142 |         if (!textures) {
      |             ^~~~~~~~~
/path/to/SDL_image/examples/showanim.c:142:9: note: Taking false branch
  142 |         if (!textures) {
      |         ^
/path/to/SDL_image/examples/showanim.c:147:21: note: Assuming 'j' is >= field 'count'
  147 |         for (j = 0; j < anim->count; ++j) {
      |                     ^~~~~~~~~~~~~~~
/path/to/SDL_image/examples/showanim.c:147:9: note: Loop condition is false. Execution continues on line 150
  147 |         for (j = 0; j < anim->count; ++j) {
      |         ^
/path/to/SDL_image/examples/showanim.c:158:9: note: Loop condition is true.  Entering loop body
  158 |         while ( ! done ) {
      |         ^
/path/to/SDL_image/examples/showanim.c:159:13: note: Loop condition is true.  Entering loop body
  159 |             while ( SDL_PollEvent(&event) ) {
      |             ^
/path/to/SDL_image/examples/showanim.c:160:17: note: Control jumps to 'case SDL_EVENT_MOUSE_BUTTON_DOWN:'  at line 186
  160 |                 switch (event.type) {
      |                 ^
/path/to/SDL_image/examples/showanim.c:188:25: note:  Execution continues on line 159
  188 |                         break;
      |                         ^
/path/to/SDL_image/examples/showanim.c:159:13: note: Loop condition is false. Execution continues on line 198
  159 |             while ( SDL_PollEvent(&event) ) {
      |             ^
/path/to/SDL_image/examples/showanim.c:204:17: note: Assuming the condition is false
  204 |             if (anim->delays[current_frame]) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/path/to/SDL_image/examples/showanim.c:204:13: note: Taking false branch
  204 |             if (anim->delays[current_frame]) {
      |             ^
/path/to/SDL_image/examples/showanim.c:213:17: note: 'once' is 0
  213 |             if (once && current_frame == 0) {
      |                 ^~~~
/path/to/SDL_image/examples/showanim.c:213:22: note: Left side of '&&' is false
  213 |             if (once && current_frame == 0) {
      |                      ^
/path/to/SDL_image/examples/showanim.c:158:9: note: Loop condition is false. Execution continues on line 218
  158 |         while ( ! done ) {
      |         ^
/path/to/SDL_image/examples/showanim.c:218:21: note: 'j' is >= field 'count'
  218 |         for (j = 0; j < anim->count; ++j) {
      |                     ^
/path/to/SDL_image/examples/showanim.c:218:9: note: Loop condition is false. Execution continues on line 221
  218 |         for (j = 0; j < anim->count; ++j) {
      |         ^
/path/to/SDL_image/examples/showanim.c:112:5: note: Loop condition is false. Execution jumps to the end of the function
  112 |     for ( i=1; argv[i]; ++i ) {
      |     ^
/path/to/SDL_image/examples/showanim.c:224:5: note: Potential leak of memory pointed to by 'textures'
  224 |     SDL_DestroyRenderer(renderer);
      |     ^
```

</p>
</details> 