### PR TITLE
Heavy Changes to Animation Stream & Animation Loading

### DIFF
--- a/VisualC/SDL_image.vcxproj
+++ b/VisualC/SDL_image.vcxproj
@@ -26,6 +26,7 @@
     <ProjectGuid>{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}</ProjectGuid>
     <RootNamespace>SDL3_image</RootNamespace>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -38,7 +39,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' != '10.0'">$(DefaultPlatformToolset)</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '10.0'">ClangCL</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -180,7 +181,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <AdditionalIncludeDirectories>external\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Users\emirm\Downloads\SDL3-3.2.16\include;external\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>DLL_EXPORT;NDEBUG;WIN32;_WINDOWS;USE_STBIMAGE;LOAD_AVIF;LOAD_AVIF_DYNAMIC="libavif-16.dll";LOAD_BMP;LOAD_GIF;LOAD_JPG;LOAD_LBM;LOAD_PCX;LOAD_PNG;LOAD_PNM;LOAD_QOI;LOAD_SVG;LOAD_TGA;LOAD_TIF;LOAD_TIF_DYNAMIC="libtiff-6.dll";LOAD_WEBP;LOAD_WEBP_DYNAMIC="libwebp-7.dll";LOAD_WEBPDEMUX_DYNAMIC="libwebpdemux-2.dll";LOAD_WEBPMUX_DYNAMIC="libwebpmux-3.dll";LOAD_LIBPNG_DYNAMIC="libpng16-16.dll";SDL_IMAGE_LIBPNG;LOAD_XCF;LOAD_XPM;LOAD_XV;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -193,12 +194,17 @@
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <AdditionalLibraryDirectories>C:\Users\emirm\Downloads\SDL_image-09e29993126b13c3dd589c5f7a5806c09b43279f\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Users\emirm\Downloads\SDL3-3.2.16\VisualC\x64\Release;C:\Users\emirm\Downloads\SDL_image-09e29993126b13c3dd589c5f7a5806c09b43279f\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy "C:\Users\emirm\OneDrive\Belgeler\sdl_image_workon\SDL_image\VisualC\x64\Release\SDL3_image.dll" "C:\Users\emirm\source\repos\SDL3_image_testbed\x64\Debug\" /I /Y
+xcopy "C:\Users\emirm\OneDrive\Belgeler\sdl_image_workon\SDL_image\VisualC\x64\Release\SDL3_image.pdb" "C:\Users\emirm\source\repos\SDL3_image_testbed\x64\Debug\" /I /Y</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\src\IMG.c" />
-    <ClCompile Include="..\src\IMG_anim.c" />
+    <ClCompile Include="..\src\IMG_anim_decoder.c" />
+    <ClCompile Include="..\src\IMG_anim_encoder.c" />
     <ClCompile Include="..\src\IMG_avif.c" />
     <ClCompile Include="..\src\IMG_bmp.c" />
     <ClCompile Include="..\src\IMG_gif.c" />
@@ -225,6 +231,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\SDL3_image\SDL_image.h" />
+    <ClInclude Include="..\src\IMG_anim_decoder.h" />
+    <ClInclude Include="..\src\IMG_anim_encoder.h" />
     <ClInclude Include="..\src\IMG_libpng.h" />
     <ClInclude Include="..\src\IMG_gif.h" />
     <ClInclude Include="..\src\IMG_avif.h" />
@@ -435,5 +443,3 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>
-
-

--- a/VisualC/SDL_image.vcxproj
+++ b/VisualC/SDL_image.vcxproj
@@ -181,7 +181,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <AdditionalIncludeDirectories>C:\Users\emirm\Downloads\SDL3-3.2.16\include;external\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>external\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>DLL_EXPORT;NDEBUG;WIN32;_WINDOWS;USE_STBIMAGE;LOAD_AVIF;LOAD_AVIF_DYNAMIC="libavif-16.dll";LOAD_BMP;LOAD_GIF;LOAD_JPG;LOAD_LBM;LOAD_PCX;LOAD_PNG;LOAD_PNM;LOAD_QOI;LOAD_SVG;LOAD_TGA;LOAD_TIF;LOAD_TIF_DYNAMIC="libtiff-6.dll";LOAD_WEBP;LOAD_WEBP_DYNAMIC="libwebp-7.dll";LOAD_WEBPDEMUX_DYNAMIC="libwebpdemux-2.dll";LOAD_WEBPMUX_DYNAMIC="libwebpmux-3.dll";LOAD_LIBPNG_DYNAMIC="libpng16-16.dll";SDL_IMAGE_LIBPNG;LOAD_XCF;LOAD_XPM;LOAD_XV;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -194,12 +194,7 @@
       <AdditionalDependencies>SDL3.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <AdditionalLibraryDirectories>C:\Users\emirm\Downloads\SDL3-3.2.16\VisualC\x64\Release;C:\Users\emirm\Downloads\SDL_image-09e29993126b13c3dd589c5f7a5806c09b43279f\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
-    <PostBuildEvent>
-      <Command>xcopy "C:\Users\emirm\OneDrive\Belgeler\sdl_image_workon\SDL_image\VisualC\x64\Release\SDL3_image.dll" "C:\Users\emirm\source\repos\SDL3_image_testbed\x64\Debug\" /I /Y
-xcopy "C:\Users\emirm\OneDrive\Belgeler\sdl_image_workon\SDL_image\VisualC\x64\Release\SDL3_image.pdb" "C:\Users\emirm\source\repos\SDL3_image_testbed\x64\Debug\" /I /Y</Command>
-    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\src\IMG.c" />
@@ -442,4 +437,5 @@ xcopy "C:\Users\emirm\OneDrive\Belgeler\sdl_image_workon\SDL_image\VisualC\x64\R
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+
 </Project>

--- a/VisualC/SDL_image.vcxproj
+++ b/VisualC/SDL_image.vcxproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset Condition="'$(VisualStudioVersion)' != '10.0'">ClangCL</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)' != '10.0'">$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -439,3 +439,4 @@
   </ImportGroup>
 
 </Project>
+

--- a/VisualC/SDL_image.vcxproj.filters
+++ b/VisualC/SDL_image.vcxproj.filters
@@ -64,7 +64,10 @@
     <ClCompile Include="..\src\IMG_libpng.c">
       <Filter>Sources</Filter>
     </ClCompile>
-    <ClCompile Include="..\src\IMG_anim.c">
+    <ClCompile Include="..\src\IMG_anim_encoder.c">
+      <Filter>Sources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\IMG_anim_decoder.c">
       <Filter>Sources</Filter>
     </ClCompile>
   </ItemGroup>
@@ -93,6 +96,12 @@
       <Filter>Sources</Filter>
     </ClInclude>
     <ClInclude Include="..\src\IMG_avif.h">
+      <Filter>Sources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\IMG_anim_encoder.h">
+      <Filter>Sources</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\IMG_anim_decoder.h">
       <Filter>Sources</Filter>
     </ClInclude>
   </ItemGroup>
@@ -169,9 +178,4 @@
       <Filter>x86</Filter>
     </CustomBuild>
   </ItemGroup>
-
 </Project>
-
-
-
-

--- a/include/SDL3_image/SDL_image.h
+++ b/include/SDL3_image/SDL_image.h
@@ -2406,7 +2406,7 @@ extern SDL_DECLSPEC IMG_Animation * SDLCALL IMG_LoadWEBPAnimation_IO(SDL_IOStrea
 /**
  * An object representing a stream of images being saved.
  */
-typedef struct IMG_AnimationStream IMG_AnimationStream;
+typedef struct IMG_AnimationEncoderStream IMG_AnimationEncoderStream;
 
 /**
  * Create an animation stream and save it to a file.
@@ -2415,17 +2415,17 @@ typedef struct IMG_AnimationStream IMG_AnimationStream;
  * be encoded using WEBP.
  *
  * \param file the file where the animation will be saved.
- * \returns a new IMG_AnimationStream, or NULL on failure; call SDL_GetError()
+ * \returns a new IMG_AnimationEncoderStream, or NULL on failure; call SDL_GetError()
  *          for more information.
  *
  * \since This function is available since SDL_image 3.4.0.
  *
- * \sa IMG_CreateAnimationStream_IO
- * \sa IMG_CreateAnimationStreamWithProperties
- * \sa IMG_AddAnimationFrame
- * \sa IMG_CloseAnimationStream
+ * \sa IMG_CreateAnimationEncoderStream_IO
+ * \sa IMG_CreateAnimationEncoderStreamWithProperties
+ * \sa IMG_AddAnimationEncoderFrame
+ * \sa IMG_CloseAnimationEncoderStream
  */
-extern SDL_DECLSPEC IMG_AnimationStream * SDLCALL IMG_CreateAnimationStream(const char *file);
+extern SDL_DECLSPEC IMG_AnimationEncoderStream * SDLCALL IMG_CreateAnimationEncoderStream(const char *file);
 
 /**
  * Create an animation stream and save it to an IOStream.
@@ -2438,67 +2438,67 @@ extern SDL_DECLSPEC IMG_AnimationStream * SDLCALL IMG_CreateAnimationStream(cons
  * \param closeio true to close the SDL_IOStream when done, false to leave it
  *                open.
  * \param type a filename extension that represent this data ("WEBP", etc).
- * \returns a new IMG_AnimationStream, or NULL on failure; call SDL_GetError()
+ * \returns a new IMG_AnimationEncoderStream, or NULL on failure; call SDL_GetError()
  *          for more information.
  *
  * \since This function is available since SDL_image 3.4.0.
  *
- * \sa IMG_CreateAnimationStream
- * \sa IMG_CreateAnimationStreamWithProperties
- * \sa IMG_AddAnimationFrame
- * \sa IMG_CloseAnimationStream
+ * \sa IMG_CreateAnimationEncoderStream
+ * \sa IMG_CreateAnimationEncoderStreamWithProperties
+ * \sa IMG_AddAnimationEncoderFrame
+ * \sa IMG_CloseAnimationEncoderStream
  */
-extern SDL_DECLSPEC IMG_AnimationStream * SDLCALL IMG_CreateAnimationStream_IO(SDL_IOStream *dst, bool closeio, const char *type);
+extern SDL_DECLSPEC IMG_AnimationEncoderStream * SDLCALL IMG_CreateAnimationEncoderStream_IO(SDL_IOStream *dst, bool closeio, const char *type);
 
 /**
  * Create an animation stream with the specified properties.
  *
  * These are the supported properties:
  *
- * - `IMG_PROP_ANIMATION_STREAM_CREATE_FILENAME_STRING`: the file to save, if
+ * - `IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_FILENAME_STRING`: the file to save, if
  *   an SDL_IOStream isn't being used. This is required if
- *   `IMG_PROP_ANIMATION_STREAM_CREATE_IOSTREAM_POINTER` isn't set.
- * - `IMG_PROP_ANIMATION_STREAM_CREATE_IOSTREAM_POINTER`: an SDL_IOStream that
+ *   `IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_IOSTREAM_POINTER` isn't set.
+ * - `IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_IOSTREAM_POINTER`: an SDL_IOStream that
  *   will be used to save the stream. This should not be closed until the
  *   animation stream is closed. This is required if
- *   `IMG_PROP_ANIMATION_STREAM_CREATE_FILENAME_STRING` isn't set.
- * - `IMG_PROP_ANIMATION_STREAM_CREATE_IOSTREAM_AUTOCLOSE_BOOLEAN`: true if
+ *   `IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_FILENAME_STRING` isn't set.
+ * - `IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_IOSTREAM_AUTOCLOSE_BOOLEAN`: true if
  *   closing the animation stream should also close the associated
  *   SDL_IOStream.
- * - `IMG_PROP_ANIMATION_STREAM_CREATE_TYPE_STRING`: the output file type,
+ * - `IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_TYPE_STRING`: the output file type,
  *   e.g. "webp", defaults to the file extension if
- *   `IMG_PROP_ANIMATION_STREAM_CREATE_FILENAME_STRING` is set.
- * - `IMG_PROP_ANIMATION_STREAM_CREATE_QUALITY_NUMBER`: the compression
+ *   `IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_FILENAME_STRING` is set.
+ * - `IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_QUALITY_NUMBER`: the compression
  *   quality, in the range of 0 to 100. The higher the number, the higher the
  *   quality and file size. This defaults to a balanced value for compression
  *   and quality.
- * - `IMG_PROP_ANIMATION_STREAM_CREATE_TIMEBASE_NUMERATOR_NUMBER`: the
+ * - `IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_TIMEBASE_NUMERATOR_NUMBER`: the
  *   numerator of the fraction used to multiply the pts to convert it to
  *   seconds. This defaults to 1.
- * - `IMG_PROP_ANIMATION_STREAM_CREATE_TIMEBASE_DENOMINATOR_NUMBER`: the
+ * - `IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_TIMEBASE_DENOMINATOR_NUMBER`: the
  *   denominator of the fraction used to multiply the pts to convert it to
  *   seconds. This defaults to 1000.
  *
  * \param props the properties of the animation stream.
- * \returns a new IMG_AnimationStream, or NULL on failure; call SDL_GetError()
+ * \returns a new IMG_AnimationEncoderStream, or NULL on failure; call SDL_GetError()
  *          for more information.
  *
  * \since This function is available since SDL_image 3.4.0.
  *
- * \sa IMG_CreateAnimationStream
- * \sa IMG_CreateAnimationStream_IO
- * \sa IMG_AddAnimationFrame
- * \sa IMG_CloseAnimationStream
+ * \sa IMG_CreateAnimationEncoderStream
+ * \sa IMG_CreateAnimationEncoderStream_IO
+ * \sa IMG_AddAnimationEncoderFrame
+ * \sa IMG_CloseAnimationEncoderStream
  */
-extern SDL_DECLSPEC IMG_AnimationStream * SDLCALL IMG_CreateAnimationStreamWithProperties(SDL_PropertiesID props);
+extern SDL_DECLSPEC IMG_AnimationEncoderStream * SDLCALL IMG_CreateAnimationEncoderStreamWithProperties(SDL_PropertiesID props);
 
-#define IMG_PROP_ANIMATION_STREAM_CREATE_FILENAME_STRING                "SDL_image.animation_stream.create.filename"
-#define IMG_PROP_ANIMATION_STREAM_CREATE_IOSTREAM_POINTER               "SDL_image.animation_stream.create.iostream"
-#define IMG_PROP_ANIMATION_STREAM_CREATE_IOSTREAM_AUTOCLOSE_BOOLEAN     "SDL_image.animation_stream.create.iostream.autoclose"
-#define IMG_PROP_ANIMATION_STREAM_CREATE_TYPE_STRING                    "SDL_image.animation_stream.create.type"
-#define IMG_PROP_ANIMATION_STREAM_CREATE_QUALITY_NUMBER                 "SDL_image.animation_stream.create.quality"
-#define IMG_PROP_ANIMATION_STREAM_CREATE_TIMEBASE_NUMERATOR_NUMBER      "SDL_image.animation_stream.create.timebase.numerator"
-#define IMG_PROP_ANIMATION_STREAM_CREATE_TIMEBASE_DENOMINATOR_NUMBER    "SDL_image.animation_stream.create.timebase.denominator"
+#define IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_FILENAME_STRING                "SDL_image.animation_encoder_stream.create.filename"
+#define IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_IOSTREAM_POINTER               "SDL_image.animation_encoder_stream.create.iostream"
+#define IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_IOSTREAM_AUTOCLOSE_BOOLEAN     "SDL_image.animation_encoder_stream.create.iostream.autoclose"
+#define IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_TYPE_STRING                    "SDL_image.animation_encoder_stream.create.type"
+#define IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_QUALITY_NUMBER                 "SDL_image.animation_encoder_stream.create.quality"
+#define IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_TIMEBASE_NUMERATOR_NUMBER      "SDL_image.animation_encoder_stream.create.timebase.numerator"
+#define IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_TIMEBASE_DENOMINATOR_NUMBER    "SDL_image.animation_encoder_stream.create.timebase.denominator"
 
 /**
  * Add a frame to a stream of images being saved.
@@ -2514,12 +2514,12 @@ extern SDL_DECLSPEC IMG_AnimationStream * SDLCALL IMG_CreateAnimationStreamWithP
  *
  * \since This function is available since SDL_image 3.4.0.
  *
- * \sa IMG_CreateAnimationStream
- * \sa IMG_CreateAnimationStream_IO
- * \sa IMG_CreateAnimationStreamWithProperties
- * \sa IMG_CloseAnimationStream
+ * \sa IMG_CreateAnimationEncoderStream
+ * \sa IMG_CreateAnimationEncoderStream_IO
+ * \sa IMG_CreateAnimationEncoderStreamWithProperties
+ * \sa IMG_CloseAnimationEncoderStream
  */
-extern SDL_DECLSPEC bool SDLCALL IMG_AddAnimationFrame(IMG_AnimationStream *stream, SDL_Surface *surface, Uint64 pts);
+extern SDL_DECLSPEC bool SDLCALL IMG_AddAnimationEncoderFrame(IMG_AnimationEncoderStream *stream, SDL_Surface *surface, Uint64 pts);
 
 /**
  * Close an animation stream, finishing any encoding.
@@ -2533,11 +2533,193 @@ extern SDL_DECLSPEC bool SDLCALL IMG_AddAnimationFrame(IMG_AnimationStream *stre
  *
  * \since This function is available since SDL_image 3.4.0.
  *
- * \sa IMG_CreateAnimationStream
- * \sa IMG_CreateAnimationStream_IO
- * \sa IMG_CreateAnimationStreamWithProperties
+ * \sa IMG_CreateAnimationEncoderStream
+ * \sa IMG_CreateAnimationEncoderStream_IO
+ * \sa IMG_CreateAnimationEncoderStreamWithProperties
  */
-extern SDL_DECLSPEC bool SDLCALL IMG_CloseAnimationStream(IMG_AnimationStream *stream);
+extern SDL_DECLSPEC bool SDLCALL IMG_CloseAnimationEncoderStream(IMG_AnimationEncoderStream *stream);
+
+/**
+ * An object representing a stream of images being loaded.
+ */
+typedef struct IMG_AnimationDecoderStream IMG_AnimationDecoderStream;
+
+typedef struct IMG_AnimationDecoderFrames
+{
+    int w;                  /**< The width of the frames */
+    int h;                  /**< The height of the frames */
+    int count;              /**< The number of frames */
+    SDL_Surface **frames;   /**< An array of frames */
+    Sint64 *delays;            /**< An array of frame delays */
+} IMG_AnimationDecoderFrames;
+
+/**
+ * Create an animation stream and save it to a file.
+ *
+ * The file type is determined from the file extension, e.g. "file.webp" will
+ * be encoded using WEBP.
+ *
+ * \param file the file where the animation will be saved.
+ * \returns a new IMG_AnimationDecoderStream, or NULL on failure; call SDL_GetError()
+ *          for more information.
+ *
+ * \since This function is available since SDL_image 3.4.0.
+ *
+ * \sa IMG_CreateAnimationDecoderStream_IO
+ * \sa IMG_CreateAnimationDecoderStreamWithProperties
+ * \sa IMG_AddAnimationDecoderFrame
+ * \sa IMG_CloseAnimationDecoderStream
+ */
+extern SDL_DECLSPEC IMG_AnimationDecoderStream * SDLCALL IMG_CreateAnimationDecoderStream(const char *file);
+
+/**
+ * Create an animation stream and save it to an IOStream.
+ *
+ * If `closeio` is true, `dst` will be closed before returning if this
+ * function fails, or when the animation stream is closed if this function
+ * succeeds.
+ *
+ * \param dst an SDL_IOStream that will be used to save the stream.
+ * \param closeio true to close the SDL_IOStream when done, false to leave it
+ *                open.
+ * \param type a filename extension that represent this data ("WEBP", etc).
+ * \returns a new IMG_AnimationDecoderStream, or NULL on failure; call SDL_GetError()
+ *          for more information.
+ *
+ * \since This function is available since SDL_image 3.4.0.
+ *
+ * \sa IMG_CreateAnimationDecoderStream
+ * \sa IMG_CreateAnimationDecoderStreamWithProperties
+ * \sa IMG_AddAnimationDecoderFrame
+ * \sa IMG_CloseAnimationDecoderStream
+ */
+extern SDL_DECLSPEC IMG_AnimationDecoderStream * SDLCALL IMG_CreateAnimationDecoderStream_IO(SDL_IOStream *dst, bool closeio, const char *type);
+
+/**
+ * Create an animation stream with the specified properties.
+ *
+ * These are the supported properties:
+ *
+ * - `IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_FILENAME_STRING`: the file to save, if
+ *   an SDL_IOStream isn't being used. This is required if
+ *   `IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_IOSTREAM_POINTER` isn't set.
+ * - `IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_IOSTREAM_POINTER`: an SDL_IOStream that
+ *   will be used to save the stream. This should not be closed until the
+ *   animation stream is closed. This is required if
+ *   `IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_FILENAME_STRING` isn't set.
+ * - `IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_IOSTREAM_AUTOCLOSE_BOOLEAN`: true if
+ *   closing the animation stream should also close the associated
+ *   SDL_IOStream.
+ * - `IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_TYPE_STRING`: the output file type,
+ *   e.g. "webp", defaults to the file extension if
+ *   `IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_FILENAME_STRING` is set.
+ *
+ * \param props the properties of the animation stream.
+ * \param decoderSettings the properties that will be filled by the decoder with decoder-specific settings if not empty.
+ * \returns a new IMG_AnimationDecoderStream, or NULL on failure; call SDL_GetError()
+ *          for more information.
+ *
+ * \since This function is available since SDL_image 3.4.0.
+ *
+ * \sa IMG_CreateAnimationDecoderStream
+ * \sa IMG_CreateAnimationDecoderStream_IO
+ * \sa IMG_AddAnimationDecoderFrame
+ * \sa IMG_CloseAnimationDecoderStream
+ */
+extern SDL_DECLSPEC IMG_AnimationDecoderStream * SDLCALL IMG_CreateAnimationDecoderStreamWithProperties(SDL_PropertiesID props);
+
+#define IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_FILENAME_STRING                "SDL_image.animation_decoder_stream.create.filename"
+#define IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_IOSTREAM_POINTER               "SDL_image.animation_decoder_stream.create.iostream"
+#define IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_IOSTREAM_AUTOCLOSE_BOOLEAN     "SDL_image.animation_decoder_stream.create.iostream.autoclose"
+#define IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_TYPE_STRING                    "SDL_image.animation_decoder_stream.create.type"
+#define IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_TIMEBASE_NUMERATOR_NUMBER      "SDL_image.animation_decoder_stream.create.timebase.numerator"
+#define IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_TIMEBASE_DENOMINATOR_NUMBER    "SDL_image.animation_decoder_stream.create.timebase.denominator"
+
+/**
+ * Add a frame to a stream of images being saved.
+ *
+ * \param stream the stream receiving images.
+ * \param framesToLoad the number of frames to load from the stream.
+ * \param frames an array of SDL_Surface pointers to fill with the loaded frames.
+ * \param delays an array of integers to fill with the frame delays, in the stated numerator and denominator unit.
+ * \param count a pointer to an integer that will be filled with the number of frames loaded.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
+ *
+ * \since This function is available since SDL_image 3.4.0.
+ *
+ * \sa IMG_CreateAnimationDecoderStream
+ * \sa IMG_CreateAnimationDecoderStream_IO
+ * \sa IMG_CreateAnimationDecoderStreamWithProperties
+ * \sa IMG_CloseAnimationDecoderStream
+ */
+extern SDL_DECLSPEC bool SDLCALL IMG_GetAnimationDecoderFrames(IMG_AnimationDecoderStream *stream, int framesToLoad, IMG_AnimationDecoderFrames* decoderFrames);
+
+/**
+ * Close an animation stream, finishing any encoding.
+ *
+ * Calling this function frees the animation stream, and returns the final
+ * status of the encoding process.
+ *
+ * \param stream the stream to close.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
+ *
+ * \since This function is available since SDL_image 3.4.0.
+ *
+ * \sa IMG_CreateAnimationDecoderStream
+ * \sa IMG_CreateAnimationDecoderStream_IO
+ * \sa IMG_CreateAnimationDecoderStreamWithProperties
+ */
+extern SDL_DECLSPEC bool SDLCALL IMG_CloseAnimationDecoderStream(IMG_AnimationDecoderStream *stream);
+
+/**
+ * Reset the animation decoder stream.
+ *
+ * Calling this function resets the animation decoder stream, allowing it to
+ * start from the beginning again. This is useful if you want to decode the
+ * frame sequence again without creating a new stream.
+ *
+ * \param stream the stream to reset.
+ * \returns true on success or false on failure; call SDL_GetError() for more
+ *          information.
+ *
+ * \since This function is available since SDL_image 3.4.0.
+ *
+ * \sa IMG_GetAnimationDecoderFrames
+ */
+extern SDL_DECLSPEC bool SDLCALL IMG_ResetAnimationDecoderStream(IMG_AnimationDecoderStream *stream);
+
+/**
+ * Create a new IMG_AnimationDecoderFrames structure.
+ *
+ * This function allocates and initializes a new IMG_AnimationDecoderFrames object,
+ * which can be used to store decoded animation frames and their associated delays.
+ * The caller is responsible for freeing the returned object using IMG_FreeAnimationDecoderFrames().
+ *
+ * \returns a pointer to a new IMG_AnimationDecoderFrames structure, or NULL on error.
+ *
+ * \since This function is available since SDL_image 3.4.0.
+ *
+ * \sa IMG_FreeAnimationDecoderFrames
+ */
+extern SDL_DECLSPEC IMG_AnimationDecoderFrames *SDLCALL IMG_CreateAnimationDecoderFrames();
+
+/**
+ * Free an IMG_AnimationDecoderFrames structure and its resources.
+ *
+ * This function releases all memory associated with the given IMG_AnimationDecoderFrames object,
+ * including the frames and delays arrays. After this call, the pointer is no longer valid.
+ *
+ * \param frames the IMG_AnimationDecoderFrames structure to free.
+ *
+ * \since This function is available since SDL_image 3.4.0.
+ *
+ * \sa IMG_CreateAnimationDecoderFrames
+ */
+extern SDL_DECLSPEC void SDLCALL IMG_FreeAnimationDecoderFrames(IMG_AnimationDecoderFrames* frames);
+
+extern SDL_DECLSPEC int SDLCALL IMG_GetAnimationDecoderPresentationTimestampMS(IMG_AnimationDecoderStream *stream, Sint64 pts);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/IMG_anim_decoder.c
+++ b/src/IMG_anim_decoder.c
@@ -1,0 +1,305 @@
+/*
+  SDL_image:  An example image loading library for use with SDL
+  Copyright (C) 1997-2025 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+#include <SDL3_image/SDL_image.h>
+
+#include "IMG_anim_decoder.h"
+#include "IMG_webp.h"
+#include "IMG_libpng.h"
+#include "IMG_gif.h"
+#include "IMG_avif.h"
+
+IMG_AnimationDecoderStream *IMG_CreateAnimationDecoderStream(const char *file)
+{
+    if (!file) {
+        SDL_InvalidParamError("file");
+        return NULL;
+    }
+
+    SDL_PropertiesID props = SDL_CreateProperties();
+    if (!props) {
+        return NULL;
+    }
+
+    SDL_SetStringProperty(props, IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_FILENAME_STRING, file);
+    IMG_AnimationDecoderStream *stream = IMG_CreateAnimationDecoderStreamWithProperties(props);
+    SDL_DestroyProperties(props);
+    return stream;
+}
+
+IMG_AnimationDecoderStream *IMG_CreateAnimationDecoderStream_IO(SDL_IOStream *dst, bool closeio, const char *type)
+{
+    if (!dst) {
+        SDL_InvalidParamError("dst");
+        return NULL;
+    }
+
+    if (!type) {
+        SDL_InvalidParamError("type");
+        return NULL;
+    }
+
+    SDL_PropertiesID props = SDL_CreateProperties();
+    if (!props) {
+        return NULL;
+    }
+
+    SDL_SetPointerProperty(props, IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_IOSTREAM_POINTER, dst);
+    SDL_SetBooleanProperty(props, IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_IOSTREAM_AUTOCLOSE_BOOLEAN, closeio);
+    SDL_SetStringProperty(props, IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_TYPE_STRING, type);
+    IMG_AnimationDecoderStream *stream = IMG_CreateAnimationDecoderStreamWithProperties(props);
+    SDL_DestroyProperties(props);
+    return stream;
+}
+
+IMG_AnimationDecoderStream *IMG_CreateAnimationDecoderStreamWithProperties(SDL_PropertiesID props)
+{
+    if (!props) {
+        SDL_InvalidParamError("props");
+        return NULL;
+    }
+
+    const char *file = SDL_GetStringProperty(props, IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_FILENAME_STRING, NULL);
+    SDL_IOStream *src = SDL_GetPointerProperty(props, IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_IOSTREAM_POINTER, NULL);
+    bool closeio = SDL_GetBooleanProperty(props, IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_IOSTREAM_AUTOCLOSE_BOOLEAN, false);
+    const char *type = SDL_GetStringProperty(props, IMG_PROP_ANIMATION_DECODER_STREAM_CREATE_TYPE_STRING, NULL);
+    int timebase_numerator = (int)SDL_GetNumberProperty(props, IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_TIMEBASE_NUMERATOR_NUMBER, 1);
+    int timebase_denominator = (int)SDL_GetNumberProperty(props, IMG_PROP_ANIMATION_ENCODER_STREAM_CREATE_TIMEBASE_DENOMINATOR_NUMBER, 1000);
+
+    if (!type || !*type) {
+        if (file) {
+            type = SDL_strrchr(file, '.');
+            if (type) {
+                // Skip the '.' in the file extension
+                ++type;
+            }
+        }
+        if (!type || !*type) {
+            SDL_SetError("Couldn't determine file type");
+            return NULL;
+        }
+    }
+
+    if (timebase_numerator <= 0) {
+        SDL_SetError("Time base numerator must be > 0");
+        return NULL;
+    }
+
+    if (timebase_denominator <= 0) {
+        SDL_SetError("Time base denominator must be > 0");
+        return NULL;
+    }
+
+    if (!src) {
+        if (!file) {
+            SDL_SetError("No output properties set");
+            return NULL;
+        }
+
+        src = SDL_IOFromFile(file, "rb");
+        if (!src) {
+            return NULL;
+        }
+        closeio = true;
+    }
+
+    IMG_AnimationDecoderStream *stream = (IMG_AnimationDecoderStream *)SDL_calloc(1, sizeof(*stream));
+    if (!stream) {
+        goto error;
+    }
+
+    stream->src = src;
+    stream->start = SDL_TellIO(src);
+    stream->closeio = closeio;
+    stream->timebase_numerator = timebase_numerator;
+    stream->timebase_denominator = timebase_denominator;
+
+    bool result = false;
+    if (SDL_strcasecmp(type, "webp") == 0) {
+        result = IMG_CreateWEBPAnimationDecoderStream(stream, props);
+    } else if (SDL_strcasecmp(type, "png") == 0) {
+        result = IMG_CreateAPNGAnimationDecoderStream(stream, props);
+    } else if (SDL_strcasecmp(type, "gif") == 0) {
+        result = IMG_CreateGIFAnimationDecoderStream(stream, props);
+    } else if (SDL_strcasecmp(type, "avifs") == 0) {
+        result = IMG_CreateAVIFAnimationDecoderStream(stream, props);
+    } else {
+        SDL_SetError("Unrecognized output type");
+    }
+
+    if (result) {
+        return stream;
+    }
+
+error:
+    if (src) {
+        if (closeio) {
+            SDL_CloseIO(src);
+        } else if (stream && stream->start >= 0) {
+            SDL_SeekIO(src, stream->start, SDL_IO_SEEK_SET);
+        }
+    }
+    if (stream) {
+        SDL_free(stream);
+    }
+    return NULL;
+}
+
+bool IMG_GetAnimationDecoderFrames(IMG_AnimationDecoderStream *stream, int framesToLoad, IMG_AnimationDecoderFrames* decoderFrames)
+{
+    if (!stream) {
+        return SDL_InvalidParamError("stream");
+    }
+    if (!decoderFrames) {
+        return SDL_InvalidParamError("frames");
+    }
+
+    return stream->GetFrames(stream, framesToLoad, decoderFrames);
+}
+
+bool IMG_CloseAnimationDecoderStream(IMG_AnimationDecoderStream *stream)
+{
+    if (!stream) {
+        return SDL_InvalidParamError("stream");
+    }
+
+    bool result = stream->Close(stream);
+    if (stream->closeio) {
+        SDL_CloseIO(stream->src);
+    }
+    SDL_free(stream);
+    return result;
+}
+
+bool IMG_ResetAnimationDecoderStream(IMG_AnimationDecoderStream *stream)
+{
+    if (!stream) {
+        return SDL_InvalidParamError("stream");
+    }
+
+    return stream->Reset(stream);
+}
+
+IMG_AnimationDecoderFrames *IMG_CreateAnimationDecoderFrames()
+{
+    IMG_AnimationDecoderFrames *frames = (IMG_AnimationDecoderFrames *)SDL_calloc(1, sizeof(*frames));
+    if (!frames) {
+        SDL_SetError("Out of memory");
+        return NULL;
+    }
+
+    return frames;
+}
+
+void IMG_FreeAnimationDecoderFrames(IMG_AnimationDecoderFrames *frames)
+{
+    if (!frames) {
+        return;
+    }
+
+    if (frames->delays) {
+        SDL_free(frames->delays);
+    }
+
+    if (frames->frames) {
+        for (int i = 0; i < frames->count; ++i) {
+            if (frames->frames[i]) {
+                SDL_DestroySurface(frames->frames[i]);
+                frames->frames[i] = NULL;
+            }
+        }
+
+        SDL_free(frames->frames);
+    }
+
+    SDL_free(frames);
+}
+
+int IMG_GetAnimationDecoderPresentationTimestampMS(IMG_AnimationDecoderStream *stream, Sint64 pts)
+{
+    return (int)((pts * 1000 * stream->timebase_numerator) / stream->timebase_denominator);
+}
+
+IMG_Animation *IMG_DecodeAsAnimation(SDL_IOStream *src, const char *format, int maxFrames)
+{
+    IMG_AnimationDecoderStream *decoder = IMG_CreateAnimationDecoderStream_IO(src, false, format);
+    if (!decoder) {
+        return NULL;
+    }
+
+    // Make sure no error is set before loading frames so we can catch any failures.
+    SDL_ClearError();
+
+    IMG_AnimationDecoderFrames *frames = IMG_CreateAnimationDecoderFrames();
+    if (!IMG_GetAnimationDecoderFrames(decoder, maxFrames, frames)) {
+        IMG_FreeAnimationDecoderFrames(frames);
+        return NULL;
+    }
+
+    if (frames->count < 1 || !frames->delays || !frames->frames) {
+        const char *err = SDL_GetError();
+        if (err[0] == '\0') {
+            SDL_SetError("No frames loaded from APNG animation");
+        } else {
+            SDL_SetError("No frames loaded from APNG animation: %s", err);
+        }
+        IMG_FreeAnimationDecoderFrames(frames);
+        return NULL;
+    }
+
+    IMG_Animation *anim = (IMG_Animation *)SDL_calloc(1, sizeof(*anim));
+    if (!anim) {
+        SDL_SetError("Out of memory for IMG_Animation");
+        IMG_FreeAnimationDecoderFrames(frames);
+        return NULL;
+    }
+    anim->count = frames->count;
+    anim->w = frames->w;
+    anim->h = frames->h;
+    anim->delays = (int *)SDL_calloc(anim->count, sizeof(*anim->delays));
+    if (!anim->delays) {
+        SDL_SetError("Out of memory for animation delays");
+        SDL_free(anim);
+        IMG_FreeAnimationDecoderFrames(frames);
+        return NULL;
+    }
+    anim->frames = (SDL_Surface **)SDL_calloc(anim->count, sizeof(*anim->frames));
+    if (!anim->frames) {
+        SDL_SetError("Out of memory for animation frames");
+        SDL_free(anim->delays);
+        SDL_free(anim);
+        IMG_FreeAnimationDecoderFrames(frames);
+        return NULL;
+    }
+
+    for (int i = 0; i < anim->count; ++i) {
+        anim->frames[i] = frames->frames[i];
+        ++anim->frames[i]->refcount; // Increment refcount since we are taking ownership of the frames
+        anim->delays[i] = IMG_GetAnimationDecoderPresentationTimestampMS(decoder, frames->delays[i]);
+        if (i > 0) {
+            anim->delays[i] /= i;
+        }
+    }
+
+    IMG_FreeAnimationDecoderFrames(frames);
+
+    return anim;
+}

--- a/src/IMG_anim_decoder.h
+++ b/src/IMG_anim_decoder.h
@@ -19,5 +19,21 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-extern bool IMG_CreateAVIFAnimationEncoderStream(IMG_AnimationEncoderStream *stream, SDL_PropertiesID props);
-extern bool IMG_CreateAVIFAnimationDecoderStream(IMG_AnimationDecoderStream *stream, SDL_PropertiesID decoderProps);
+typedef struct IMG_AnimationDecoderStreamContext IMG_AnimationDecoderStreamContext;
+
+struct IMG_AnimationDecoderStream
+{
+    SDL_IOStream *src;
+    Sint64 start;
+    bool closeio;
+    int timebase_numerator;
+    int timebase_denominator;
+
+    bool (*GetFrames)(IMG_AnimationDecoderStream *stream, int framesToLoad, IMG_AnimationDecoderFrames* decoderFrames);
+    bool (*Reset)(IMG_AnimationDecoderStream *stream);
+    bool (*Close)(IMG_AnimationDecoderStream *stream);
+
+    IMG_AnimationDecoderStreamContext *ctx;
+};
+
+extern IMG_Animation *IMG_DecodeAsAnimation(SDL_IOStream *src, const char *format, int maxFrames);

--- a/src/IMG_anim_encoder.h
+++ b/src/IMG_anim_encoder.h
@@ -19,9 +19,9 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-typedef struct IMG_AnimationStreamContext IMG_AnimationStreamContext;
+typedef struct IMG_AnimationEncoderStreamContext IMG_AnimationEncoderStreamContext;
 
-struct IMG_AnimationStream
+struct IMG_AnimationEncoderStream
 {
     SDL_IOStream *dst;
     Sint64 start;
@@ -32,11 +32,11 @@ struct IMG_AnimationStream
     Uint64 first_pts;
     Uint64 last_pts;
 
-    bool (*AddFrame)(IMG_AnimationStream *stream, SDL_Surface *surface, Uint64 pts);
-    bool (*Close)(IMG_AnimationStream *stream);
+    bool (*AddFrame)(IMG_AnimationEncoderStream *stream, SDL_Surface *surface, Uint64 pts);
+    bool (*Close)(IMG_AnimationEncoderStream *stream);
 
-    IMG_AnimationStreamContext *ctx;
+    IMG_AnimationEncoderStreamContext *ctx;
 };
 
-extern int GetStreamPresentationTimestampMS(IMG_AnimationStream *stream, Uint64 pts);
+extern int GetStreamPresentationTimestampMS(IMG_AnimationEncoderStream *stream, Uint64 pts);
 

--- a/src/IMG_gif.h
+++ b/src/IMG_gif.h
@@ -19,4 +19,5 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-extern bool IMG_CreateGIFAnimationStream(IMG_AnimationStream *stream, SDL_PropertiesID props);
+extern bool IMG_CreateGIFAnimationEncoderStream(IMG_AnimationEncoderStream *stream, SDL_PropertiesID props);
+extern bool IMG_CreateGIFAnimationDecoderStream(IMG_AnimationDecoderStream *stream, SDL_PropertiesID decoderProps);

--- a/src/IMG_libpng.h
+++ b/src/IMG_libpng.h
@@ -19,4 +19,5 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-extern bool IMG_CreateAPNGAnimationStream(IMG_AnimationStream *stream, SDL_PropertiesID props);
+extern bool IMG_CreateAPNGAnimationEncoderStream(IMG_AnimationEncoderStream *stream, SDL_PropertiesID props);
+extern bool IMG_CreateAPNGAnimationDecoderStream(IMG_AnimationDecoderStream *stream, SDL_PropertiesID decoderProps);

--- a/src/IMG_webp.h
+++ b/src/IMG_webp.h
@@ -19,5 +19,6 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
-extern bool IMG_CreateWEBPAnimationStream(IMG_AnimationStream *stream, SDL_PropertiesID props);
+extern bool IMG_CreateWEBPAnimationEncoderStream(IMG_AnimationEncoderStream *stream, SDL_PropertiesID props);
+extern bool IMG_CreateWEBPAnimationDecoderStream(IMG_AnimationDecoderStream *stream, SDL_PropertiesID decoderProps);
 


### PR DESCRIPTION
Introducing the changes mentioned in #599 in most possible efficient ways.

### Changes
- Verify all calls to SDL functions returns successful, the previous implementation in GIF and PNG wasn't checking whether `SDL_BlitSurface` and such's return value or not.
- Rename `IMG_AnimationStream` to `IMG_AnimationEncoderStream`.
- Rename all pre-defined settings for `IMG_AnimationEncoderStream` to include `encoder` prefix.
- Introduce `IMG_AnimationDecoderStream`.
- Introduce similar pre-defined settings for `IMG_AnimationDecoderStream`.
- Change existing animation loading API to use IMG_AnimationDecoderStream in the background. This has been done smoothly with a single call to `IMG_DecodeAsAnimation` for all formats.

### Planned
- Review the code for bugs.
- Review the changes to ensure it will behave the same as the previous implementation.
- Review encoder-specific settings for exposed API to include defines for most standardized ones (e.g. loop count).

### Actual Design
`IMG_CreateAnimationDecoderStreamWithProperties` to be called with `SDL_PropertiesID` for both inputs and outputs. This means the decoder stream can be used to extract data, and user should not be forced to load any frames at all. The existing implementation supports this. You only create the decoder stream, and then check your `SDL_PropertiesID` with filled data, then free it before getting any frames.

`GetFrames` works with the new struct `IMG_AnimationDecoderFrames` for holding the frame data, this has been created to isolate from the existing `IMG_Animation` interface completely and to hold `PTS` instead of integer milliseconds for flexibility.
The current `IMG_AnimationDecoderFrames` holds `PTS` in the desired `timebase_numerator` and `timebase_denominator`, no precision will be lost for sensitive animation decoders.

`Reset` works by rewinding the underlying iterator/SDL_IOStream/DecoderContext depending on the format and resets all frame indexing to 0 or -1 for re-reading from the beginning. The naming kept simple but can be changed if not met with the requirementes of the existing API. It's purpose is to be able to re-use the existing decoder stream for looping without having to destroy and re-create the entire context. **This (Reset function/feature) remains untested as of (8/8/2025 06:33 PM).**

Other functions `Close` and `IMG_CreateAnimationDecoderStreamWithProperties` are identical to our encoder counterparts.
Please feel free to recommend changes as needed, and make sure to review the changes carefully to make sure no mistakes are made.