### PR TITLE
Animation Encoding/Cecoding Metadata (aka PROPS) Feature

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -75,6 +75,7 @@ LOCAL_SRC_FILES :=  		\
     src/IMG.c           	\
     src/IMG_anim_encoder.c      \
     src/IMG_anim_decoder.c      \
+    src/xmlman.c      		\
     src/IMG_avif.c      	\
     src/IMG_bmp.c       	\
     src/IMG_gif.c       	\

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,7 @@ add_library(${sdl3_image_target_name}
     src/IMG_WIC.c
     src/IMG_anim_encoder.c
     src/IMG_anim_decoder.c
+    src/xmlman.c
     src/IMG_avif.c
     src/IMG_bmp.c
     src/IMG_gif.c

--- a/include/SDL3_image/SDL_image.h
+++ b/include/SDL3_image/SDL_image.h
@@ -2403,6 +2403,14 @@ extern SDL_DECLSPEC IMG_Animation * SDLCALL IMG_LoadGIFAnimation_IO(SDL_IOStream
  */
 extern SDL_DECLSPEC IMG_Animation * SDLCALL IMG_LoadWEBPAnimation_IO(SDL_IOStream *src);
 
+#define IMG_PROP_ANIMATION_IGNORE_PROPS_BOOLEAN                 "SDL_image.animation.ignore_props"
+#define IMG_PROP_ANIMATION_DESCRIPTION_STRING                   "SDL_image.animation.description"
+#define IMG_PROP_ANIMATION_COPYRIGHT_STRING                     "SDL_image.animation.copyright"
+#define IMG_PROP_ANIMATION_TITLE_STRING                         "SDL_image.animation.title"
+#define IMG_PROP_ANIMATION_AUTHOR_STRING                        "SDL_image.animation.author"
+#define IMG_PROP_ANIMATION_CREATION_TIME_STRING                 "SDL_image.animation.creation_time"
+#define IMG_PROP_ANIMATION_LOOP_COUNT_NUMBER                    "SDL_image.animation.loop_count"
+
 /**
  * An object representing the encoder context.
  */
@@ -2627,6 +2635,26 @@ extern SDL_DECLSPEC IMG_AnimationDecoder * SDLCALL IMG_CreateAnimationDecoderWit
 #define IMG_PROP_ANIMATION_DECODER_CREATE_TYPE_STRING                    "SDL_image.animation_decoder.create.type"
 #define IMG_PROP_ANIMATION_DECODER_CREATE_TIMEBASE_NUMERATOR_NUMBER      "SDL_image.animation_decoder.create.timebase.numerator"
 #define IMG_PROP_ANIMATION_DECODER_CREATE_TIMEBASE_DENOMINATOR_NUMBER    "SDL_image.animation_decoder.create.timebase.denominator"
+
+
+/**
+ * Get the properties of an animation decoder.
+ *
+ * This function returns the properties of the animation decoder, which
+ * holds information about the underlying image such as description,
+ * copyright text and loop count.
+ *
+ * \param decoder the animation decoder.
+ * \returns the properties ID of the animation decoder, or 0 if there are no
+ *          properties; call SDL_GetError() for more information.
+ *
+ * \since This function is available since SDL_image 3.4.0.
+ *
+ * \sa IMG_CreateAnimationDecoder
+ * \sa IMG_CreateAnimationDecoder_IO
+ * \sa IMG_CreateAnimationDecoderWithProperties
+ */
+extern SDL_DECLSPEC SDL_PropertiesID SDLCALL IMG_GetAnimationDecoderProperties(IMG_AnimationDecoder* decoder);
 
 /**
  * Get the next frame in an animation decoder.

--- a/src/IMG_anim_decoder.c
+++ b/src/IMG_anim_decoder.c
@@ -131,6 +131,11 @@ IMG_AnimationDecoder *IMG_CreateAnimationDecoderWithProperties(SDL_PropertiesID 
     decoder->closeio = closeio;
     decoder->timebase_numerator = timebase_numerator;
     decoder->timebase_denominator = timebase_denominator;
+    decoder->props = SDL_CreateProperties();
+    if (!decoder->props) {
+        SDL_SetError("Failed to create properties for animation decoder");
+        goto error;
+    }
 
     bool result = false;
     if (SDL_strcasecmp(type, "webp") == 0) {
@@ -161,6 +166,16 @@ error:
         SDL_free(decoder);
     }
     return NULL;
+}
+
+SDL_PropertiesID IMG_GetAnimationDecoderProperties(IMG_AnimationDecoder *decoder)
+{
+    if (!decoder) {
+        SDL_InvalidParamError("decoder");
+        return 0;
+    }
+
+    return decoder->props;
 }
 
 bool IMG_GetAnimationDecoderFrame(IMG_AnimationDecoder *decoder, SDL_Surface **frame, Uint64 *pts)
@@ -196,6 +211,11 @@ bool IMG_CloseAnimationDecoder(IMG_AnimationDecoder *decoder)
 
     if (decoder->closeio) {
         result &= SDL_CloseIO(decoder->src);
+    }
+
+    if (decoder->props) {
+        SDL_DestroyProperties(decoder->props);
+        decoder->props = 0;
     }
 
     SDL_free(decoder);

--- a/src/IMG_anim_decoder.h
+++ b/src/IMG_anim_decoder.h
@@ -34,6 +34,7 @@ struct IMG_AnimationDecoder
     bool (*Close)(IMG_AnimationDecoder *decoder);
 
     IMG_AnimationDecoderContext *ctx;
+    SDL_PropertiesID props;
 };
 
 extern IMG_Animation *IMG_DecodeAsAnimation(SDL_IOStream *src, const char *format, int maxFrames);

--- a/src/IMG_avif.c
+++ b/src/IMG_avif.c
@@ -24,6 +24,7 @@
 #include <SDL3_image/SDL_image.h>
 #include "IMG_anim_encoder.h"
 #include "IMG_anim_decoder.h"
+#include "xmlman.h"
 
 /* We'll have AVIF save support by default */
 #if !defined(SAVE_AVIF)
@@ -73,6 +74,9 @@ static struct {
     void (*avifRGBImageSetDefaults)(avifRGBImage * rgb, const avifImage * image);
     void (*avifRWDataFree)(avifRWData * raw);
     const char * (*avifResultToString)(avifResult res);
+
+    // XMP metadata support
+    avifResult (*avifImageSetMetadataXMP)(avifImage * image, const uint8_t * xmp, size_t xmpSize);
 } lib;
 
 #ifdef LOAD_AVIF_DYNAMIC
@@ -115,6 +119,9 @@ static bool IMG_InitAVIF(void)
         FUNCTION_LOADER(avifRGBImageSetDefaults, void (*)(avifRGBImage * rgb, const avifImage * image))
         FUNCTION_LOADER(avifRWDataFree, void (*)(avifRWData * raw))
         FUNCTION_LOADER(avifResultToString, const char * (*)(avifResult res))
+
+        // XMP metadata support
+        FUNCTION_LOADER(avifImageSetMetadataXMP, avifResult (*)(avifImage * image, const uint8_t * xmp, size_t xmpSize))
     }
     ++lib.loaded;
 
@@ -1014,7 +1021,7 @@ static bool IMG_AnimationDecoderGetNextFrame_Internal(IMG_AnimationDecoder *deco
     }
 
     if (ctx->decoder->imageTiming.timescale > 0) {
-        *pts = (Sint64)ctx->decoder->imageTiming.ptsInTimescales * decoder->timebase_denominator / (ctx->decoder->imageTiming.timescale * decoder->timebase_numerator);
+        *pts = (Uint64)ctx->decoder->imageTiming.ptsInTimescales * decoder->timebase_denominator / (ctx->decoder->imageTiming.timescale * decoder->timebase_numerator);
     } else {
         *pts = 0;
     }
@@ -1025,9 +1032,9 @@ static bool IMG_AnimationDecoderGetNextFrame_Internal(IMG_AnimationDecoder *deco
     return true;
 }
 
-static bool IMG_AnimationDecoderClose_Internal(IMG_AnimationDecoder* decoder)
+static bool IMG_AnimationDecoderClose_Internal(IMG_AnimationDecoder *decoder)
 {
-    IMG_AnimationDecoderContext* ctx = decoder->ctx;
+    IMG_AnimationDecoderContext *ctx = decoder->ctx;
 
     if (ctx->decoder) {
         lib.avifDecoderDestroy(ctx->decoder);
@@ -1042,6 +1049,27 @@ static bool IMG_AnimationDecoderClose_Internal(IMG_AnimationDecoder* decoder)
 
     SDL_free(ctx);
     decoder->ctx = NULL;
+
+    const char *desc = SDL_GetStringProperty(decoder->props, IMG_PROP_ANIMATION_DESCRIPTION_STRING, NULL);
+    const char *rights = SDL_GetStringProperty(decoder->props, IMG_PROP_ANIMATION_COPYRIGHT_STRING, NULL);
+    const char *title = SDL_GetStringProperty(decoder->props, IMG_PROP_ANIMATION_TITLE_STRING, NULL);
+    const char *creator = SDL_GetStringProperty(decoder->props, IMG_PROP_ANIMATION_AUTHOR_STRING, NULL);
+    const char *createdate = SDL_GetStringProperty(decoder->props, IMG_PROP_ANIMATION_CREATION_TIME_STRING, NULL);
+    if (desc) {
+        SDL_free((void *)desc);
+    }
+    if (rights) {
+        SDL_free((void *)rights);
+    }
+    if (title) {
+        SDL_free((void *)title);
+    }
+    if (creator) {
+        SDL_free((void *)creator);
+    }
+    if (createdate) {
+        SDL_free((void *)createdate);
+    }
 
     return true;
 }
@@ -1095,12 +1123,9 @@ bool IMG_CreateAVIFAnimationDecoder(IMG_AnimationDecoder *decoder, SDL_Propertie
         bool allowIncremental = SDL_GetBooleanProperty(props, "avif.allowincremental", false);
         ctx->decoder->allowIncremental = allowIncremental ? AVIF_TRUE : AVIF_FALSE;
 
-        // Optional properties for ignoring metadata
-        bool ignoreExif = SDL_GetBooleanProperty(props, "avif.ignoreexif", false);
-        ctx->decoder->ignoreExif = ignoreExif ? AVIF_TRUE : AVIF_FALSE;
-
-        bool ignoreXMP = SDL_GetBooleanProperty(props, "avif.ignorexmp", false);
-        ctx->decoder->ignoreXMP = ignoreXMP ? AVIF_TRUE : AVIF_FALSE;
+        bool ignoreProps = SDL_GetBooleanProperty(props, IMG_PROP_ANIMATION_IGNORE_PROPS_BOOLEAN, false);
+        ctx->decoder->ignoreExif = ignoreProps ? AVIF_TRUE : AVIF_FALSE;
+        ctx->decoder->ignoreXMP = ignoreProps ? AVIF_TRUE : AVIF_FALSE;
     }
 
     decoder->ctx = ctx;
@@ -1127,8 +1152,42 @@ bool IMG_CreateAVIFAnimationDecoder(IMG_AnimationDecoder *decoder, SDL_Propertie
     ctx->total_frames = ctx->decoder->imageCount;
     ctx->repetitionCount = ctx->decoder->repetitionCount;
 
-    //SDL_SetNumberProperty(decoder->metadata, IMG_PROP_ANIMATION_DECODER_METADATA_FRAME_COUNT_NUMBER, ctx->total_frames);
-    //SDL_SetNumberProperty(decoder->metadata, IMG_PROP_ANIMATION_DECODER_METADATA_LOOP_COUNT_NUMBER, ctx->repetitionCount);
+    bool ignoreProps = SDL_GetBooleanProperty(props, IMG_PROP_ANIMATION_IGNORE_PROPS_BOOLEAN, false);
+    if (!ignoreProps) {
+        // Allow implicit properties to be set which are not globalized but specific to the decoder.
+        SDL_SetNumberProperty(decoder->props, "IMG_PROP_ANIMATION_DECODER_FRAME_COUNT_NUMBER", ctx->total_frames);
+
+        // Set well-defined properties.
+        SDL_SetNumberProperty(decoder->props, IMG_PROP_ANIMATION_LOOP_COUNT_NUMBER, ctx->repetitionCount);
+
+        // Get other well-defined properties and set them in our props.
+        if (!ctx->decoder->ignoreXMP) {
+            uint8_t *data = ctx->decoder->image->xmp.data;
+            size_t len = ctx->decoder->image->xmp.size;
+            if (data && len > 0) {
+                const char *desc = __xmlman_GetXMPDescription(data, len);
+                const char *rights = __xmlman_GetXMPCopyright(data, len);
+                const char *title = __xmlman_GetXMPTitle(data, len);
+                const char *creator = __xmlman_GetXMPCreator(data, len);
+                const char *createDate = __xmlman_GetXMPCreateDate(data, len);
+                if (desc) {
+                    SDL_SetStringProperty(decoder->props, IMG_PROP_ANIMATION_DESCRIPTION_STRING, desc);
+                }
+                if (rights) {
+                    SDL_SetStringProperty(decoder->props, IMG_PROP_ANIMATION_COPYRIGHT_STRING, rights);
+                }
+                if (title) {
+                    SDL_SetStringProperty(decoder->props, IMG_PROP_ANIMATION_TITLE_STRING, title);
+                }
+                if (creator) {
+                    SDL_SetStringProperty(decoder->props, IMG_PROP_ANIMATION_AUTHOR_STRING, creator);
+                }
+                if (createDate) {
+                    SDL_SetStringProperty(decoder->props, IMG_PROP_ANIMATION_CREATION_TIME_STRING, createDate);
+                }
+            }
+        }
+    }
 
     return true;
 }
@@ -1157,6 +1216,11 @@ struct IMG_AnimationEncoderContext
 {
     avifEncoder *encoder;
     bool first_frame_added;
+    const char *rights;
+    const char *desc;
+    const char *title;
+    const char *creator;
+    const char *createdate;
 };
 
 static bool AnimationEncoder_AddFrame(struct IMG_AnimationEncoder *encoder, SDL_Surface *surface, Uint64 pts)
@@ -1198,6 +1262,17 @@ static bool AnimationEncoder_AddFrame(struct IMG_AnimationEncoder *encoder, SDL_
     image = lib.avifImageCreate(surface->w, surface->h, depth, pixelFormat);
     if (!image) {
         return SDL_SetError("Couldn't create AVIF image");
+    }
+
+    if (!encoder->ctx->first_frame_added && (encoder->ctx->desc || encoder->ctx->rights)) {
+        size_t outlen = 0;
+        uint8_t *xmp_data = __xmlman_ConstructXMPWithRDFDescription(encoder->ctx->title, encoder->ctx->creator, encoder->ctx->desc, encoder->ctx->rights, encoder->ctx->createdate, &outlen);
+        if (!xmp_data || outlen < 1) {
+            lib.avifImageDestroy(image);
+            return SDL_SetError("Couldn't create XMP data for AVIF image");
+        }
+        lib.avifImageSetMetadataXMP(image, xmp_data, outlen);
+        SDL_free((void *)xmp_data);
     }
 
     image->yuvRange = AVIF_RANGE_FULL;
@@ -1556,6 +1631,20 @@ bool IMG_CreateAVIFAnimationEncoder(IMG_AnimationEncoder *encoder, SDL_Propertie
         encoder->ctx->encoder->timescale = (uint32_t)encoder->timebase_denominator;
     } else {
         encoder->ctx->encoder->timescale = 1000;
+    }
+
+    bool ignoreProps = SDL_GetBooleanProperty(props, IMG_PROP_ANIMATION_IGNORE_PROPS_BOOLEAN, false);
+    if (!ignoreProps) {
+        encoder->ctx->encoder->repetitionCount = (int)SDL_GetNumberProperty(props, IMG_PROP_ANIMATION_LOOP_COUNT_NUMBER, -1);
+        if (encoder->ctx->encoder->repetitionCount < 1 && encoder->ctx->encoder->repetitionCount != -1) {
+            encoder->ctx->encoder->repetitionCount = -1;
+        }
+
+        encoder->ctx->desc = SDL_GetStringProperty(props, IMG_PROP_ANIMATION_DESCRIPTION_STRING, NULL);
+        encoder->ctx->rights = SDL_GetStringProperty(props, IMG_PROP_ANIMATION_COPYRIGHT_STRING, NULL);
+        encoder->ctx->title = SDL_GetStringProperty(props, IMG_PROP_ANIMATION_TITLE_STRING, NULL);
+        encoder->ctx->creator = SDL_GetStringProperty(props, IMG_PROP_ANIMATION_AUTHOR_STRING, NULL);
+        encoder->ctx->createdate = SDL_GetStringProperty(props, IMG_PROP_ANIMATION_CREATION_TIME_STRING, NULL);
     }
 
     encoder->ctx->first_frame_added = false;

--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -26,6 +26,7 @@
 #include "IMG_anim_encoder.h"
 #include "IMG_anim_decoder.h"
 #include "IMG_webp.h"
+#include "xmlman.h"
 
 // We will have the saving WEBP feature by default
 #if !defined(SAVE_WEBP)
@@ -93,6 +94,19 @@ static struct
     int (*WebPAnimEncoderAdd)(WebPAnimEncoder *, WebPPicture *, int, const WebPConfig *);     // Export #29 (0x001d),  (0x), 0x00003e60, None
     int (*WebPAnimEncoderAssemble)(WebPAnimEncoder *, WebPData *);                            // Export #30 (0x001e),  (0x), 0x00004580, None
     void (*WebPAnimEncoderDelete)(WebPAnimEncoder *);                                         // Export #31 (0x001f),  (0x), 0x00003cb0, None
+
+    // Used for extracting EXIF & XMP chunks.
+    int (*WebPDemuxGetChunk)(const WebPDemuxer* dmux, const char fourcc[4], int chunk_number, WebPChunkIterator* iter);
+    void (*WebPDemuxReleaseChunkIterator)(WebPChunkIterator* iter);
+
+    // Used for setting EXIF & XMP chunks and for loop count.
+    WebPMux *(*WebPMuxCreateInternal)(const WebPData*, int, int); // Export 38 (0x0026),  (0x), 0x00006e90, None
+    void (*WebPMuxDelete)(WebPMux* mux);
+    WebPMuxError (*WebPMuxSetChunk)(WebPMux *mux, const char fourcc[4], const WebPData *chunk_data, int copy_data);
+    WebPMuxError (*WebPMuxGetAnimationParams)(const WebPMux *mux, WebPMuxAnimParams *params);
+    WebPMuxError (*WebPMuxSetAnimationParams)(WebPMux* mux, const WebPMuxAnimParams* params);
+
+    WebPMuxError (*WebPMuxAssemble)(WebPMux* mux, WebPData* assembled_data);
 } lib;
 
 #if defined(LOAD_WEBP_DYNAMIC) && defined(LOAD_WEBPDEMUX_DYNAMIC) && defined(LOAD_WEBPMUX_DYNAMIC)
@@ -184,6 +198,18 @@ static bool IMG_InitWEBP(void)
         FUNCTION_LOADER_LIBWEBPMUX(WebPAnimEncoderAdd, int (*)(WebPAnimEncoder *, WebPPicture *, int, const WebPConfig *))
         FUNCTION_LOADER_LIBWEBPMUX(WebPAnimEncoderAssemble, int (*)(WebPAnimEncoder *, WebPData *))
         FUNCTION_LOADER_LIBWEBPMUX(WebPAnimEncoderDelete, void (*)(WebPAnimEncoder *))
+
+        // Used for extracting EXIF & XMP chunks.
+        FUNCTION_LOADER_LIBWEBPDEMUX(WebPDemuxGetChunk, int (*)(const WebPDemuxer *dmux, const char fourcc[4], int chunk_number, WebPChunkIterator *iter))
+        FUNCTION_LOADER_LIBWEBPDEMUX(WebPDemuxReleaseChunkIterator, void (*)(WebPChunkIterator* iter))
+
+        // Used for setting EXIF & XMP chunks and for loop count.
+        FUNCTION_LOADER_LIBWEBPMUX(WebPMuxCreateInternal, WebPMux * (*)(const WebPData*, int, int))
+        FUNCTION_LOADER_LIBWEBPMUX(WebPMuxDelete, void (*)(WebPMux* mux))
+        FUNCTION_LOADER_LIBWEBPMUX(WebPMuxSetChunk, WebPMuxError (*)(WebPMux *mux, const char fourcc[4], const WebPData *chunk_data, int copy_data))
+        FUNCTION_LOADER_LIBWEBPMUX(WebPMuxGetAnimationParams, WebPMuxError (*)(const WebPMux* mux, WebPMuxAnimParams* params))
+        FUNCTION_LOADER_LIBWEBPMUX(WebPMuxSetAnimationParams, WebPMuxError (*)(WebPMux* mux, const WebPMuxAnimParams* params))
+        FUNCTION_LOADER_LIBWEBPMUX(WebPMuxAssemble, WebPMuxError (*)(WebPMux* mux, WebPData* assembled_data))
     }
     ++lib.loaded;
 
@@ -505,13 +531,32 @@ static bool IMG_AnimationDecoderClose_Internal(IMG_AnimationDecoder *decoder)
     lib.WebPDemuxReleaseIterator(&decoder->ctx->iter);
     SDL_free(decoder->ctx);
     decoder->ctx = NULL;
+
+    const char *desc = SDL_GetStringProperty(decoder->props, IMG_PROP_ANIMATION_DESCRIPTION_STRING, NULL);
+    const char *rights = SDL_GetStringProperty(decoder->props, IMG_PROP_ANIMATION_COPYRIGHT_STRING, NULL);
+    const char *title = SDL_GetStringProperty(decoder->props, IMG_PROP_ANIMATION_TITLE_STRING, NULL);
+    const char *creator = SDL_GetStringProperty(decoder->props, IMG_PROP_ANIMATION_AUTHOR_STRING, NULL);
+    const char *creationtime = SDL_GetStringProperty(decoder->props, IMG_PROP_ANIMATION_CREATION_TIME_STRING, NULL);
+    if (desc) {
+        SDL_free((void *)desc);
+    }
+    if (rights) {
+        SDL_free((void *)rights);
+    }
+    if (title) {
+        SDL_free((void *)title);
+    }
+    if (creator) {
+        SDL_free((void *)creator);
+    }
+    if (creationtime) {
+        SDL_free((void *)creationtime);
+    }
     return true;
 }
 
 bool IMG_CreateWEBPAnimationDecoder(IMG_AnimationDecoder *decoder, SDL_PropertiesID props)
 {
-    (void)props;
-
     if (!IMG_InitWEBP()) {
         SDL_SetError("Failed to initialize WEBP library");
         return false;
@@ -565,8 +610,42 @@ bool IMG_CreateWEBPAnimationDecoder(IMG_AnimationDecoder *decoder, SDL_Propertie
     uint32_t height = lib.WebPDemuxGetI(decoder->ctx->demuxer, WEBP_FF_CANVAS_HEIGHT);
     uint32_t flags = lib.WebPDemuxGetI(decoder->ctx->demuxer, WEBP_FF_FORMAT_FLAGS);
 
-    //SDL_SetNumberProperty(decoder->metadata, IMG_PROP_ANIMATION_DECODER_METADATA_FRAME_COUNT_NUMBER, lib.WebPDemuxGetI(decoder->ctx->demuxer, WEBP_FF_FRAME_COUNT));
-    //SDL_SetNumberProperty(decoder->metadata, IMG_PROP_ANIMATION_DECODER_METADATA_LOOP_COUNT_NUMBER, lib.WebPDemuxGetI(decoder->ctx->demuxer, WEBP_FF_LOOP_COUNT));
+    bool ignoreProps = SDL_GetBooleanProperty(props, IMG_PROP_ANIMATION_IGNORE_PROPS_BOOLEAN, false);
+    if (!ignoreProps) {
+        // Allow implicit properties to be set which are not globalized but specific to the decoder.
+        SDL_SetNumberProperty(decoder->props, "IMG_PROP_ANIMATION_DECODER_FRAME_COUNT_NUMBER", lib.WebPDemuxGetI(decoder->ctx->demuxer, WEBP_FF_FRAME_COUNT));
+
+        // Set well-defined properties.
+        SDL_SetNumberProperty(decoder->props, IMG_PROP_ANIMATION_LOOP_COUNT_NUMBER, lib.WebPDemuxGetI(decoder->ctx->demuxer, WEBP_FF_LOOP_COUNT));
+
+        // Get other well-defined properties and set them in our props.
+        WebPChunkIterator xmp_iter;
+        if (lib.WebPDemuxGetChunk(decoder->ctx->demuxer, "XMP ", 1, &xmp_iter)) {
+            if (xmp_iter.chunk.bytes && xmp_iter.chunk.size > 0) {
+                const char *desc = __xmlman_GetXMPDescription(xmp_iter.chunk.bytes, xmp_iter.chunk.size);
+                const char *rights = __xmlman_GetXMPCopyright(xmp_iter.chunk.bytes, xmp_iter.chunk.size);
+                const char *title = __xmlman_GetXMPTitle(xmp_iter.chunk.bytes, xmp_iter.chunk.size);
+                const char *creator = __xmlman_GetXMPCreator(xmp_iter.chunk.bytes, xmp_iter.chunk.size);
+                const char *createdate = __xmlman_GetXMPCreateDate(xmp_iter.chunk.bytes, xmp_iter.chunk.size);
+                if (desc) {
+                    SDL_SetStringProperty(decoder->props, IMG_PROP_ANIMATION_DESCRIPTION_STRING, desc);
+                }
+                if (rights) {
+                    SDL_SetStringProperty(decoder->props, IMG_PROP_ANIMATION_COPYRIGHT_STRING, rights);
+                }
+                if (title) {
+                    SDL_SetStringProperty(decoder->props, IMG_PROP_ANIMATION_TITLE_STRING, title);
+                }
+                if (creator) {
+                    SDL_SetStringProperty(decoder->props, IMG_PROP_ANIMATION_AUTHOR_STRING, creator);
+                }
+                if (createdate) {
+                    SDL_SetStringProperty(decoder->props, IMG_PROP_ANIMATION_CREATION_TIME_STRING, createdate);
+                }
+            }
+            lib.WebPDemuxReleaseChunkIterator(&xmp_iter);
+        }
+    }
 
     bool has_alpha = (flags & 0x10) != 0;
 
@@ -786,6 +865,12 @@ struct IMG_AnimationEncoderContext
     WebPAnimEncoder *encoder;
     WebPConfig config;
     int frames;
+    const char *desc;
+    const char *rights;
+    const char *title;
+    const char *creator;
+    const char *creationtime;
+    int loop_count;
 };
 
 static bool IMG_AddWEBPAnimationFrame(IMG_AnimationEncoder *encoder, SDL_Surface *surface, Uint64 pts)
@@ -852,11 +937,12 @@ static bool IMG_CloseWEBPAnimation(IMG_AnimationEncoder *encoder)
     IMG_AnimationEncoderContext *ctx = encoder->ctx;
     const char *error = NULL;
     WebPData data = { NULL, 0 };
+    WebPMux *mux = NULL;
 
     if (!ctx->encoder) {
         error = "No frames added to animation";
         goto done;
-    }
+    } 
 
     int timestamp = GetStreamPresentationTimestampMS(encoder, encoder->last_pts);
     if (ctx->frames > 1) {
@@ -867,9 +953,68 @@ static bool IMG_CloseWEBPAnimation(IMG_AnimationEncoder *encoder)
         goto done;
     }
 
-    if (!lib.WebPAnimEncoderAssemble(ctx->encoder, &data)) {
-        error = "WebPAnimEncoderAssemble() failed";
-        goto done;
+    if (!ctx->rights && !ctx->desc && ctx->loop_count == 0)
+    {
+        if (!lib.WebPAnimEncoderAssemble(ctx->encoder, &data)) {
+            error = "WebPAnimEncoderAssemble() failed";
+            goto done;
+        }
+    } else {
+        WebPMuxError muxErr;
+        WebPData pdata = { NULL, 0 };
+        if (!lib.WebPAnimEncoderAssemble(ctx->encoder, &pdata)) {
+            error = "WebPAnimEncoderAssemble() failed";
+            goto done;
+        }
+
+        mux = lib.WebPMuxCreateInternal(&pdata, 1, WEBP_MUX_ABI_VERSION);
+        if (!mux) {
+            error = "WebPMuxCreate() failed";
+            goto done;
+        }
+
+        WebPMuxAnimParams params;
+        muxErr = lib.WebPMuxGetAnimationParams(mux, &params);
+        if (muxErr != WEBP_MUX_OK) {
+            lib.WebPMuxDelete(mux);
+            error = "WebPMuxCreate() failed";
+            goto done;
+        }
+        params.loop_count = ctx->loop_count;
+        muxErr = lib.WebPMuxSetAnimationParams(mux, &params);
+        if (muxErr != WEBP_MUX_OK) {
+            lib.WebPMuxDelete(mux);
+            error = "WebPMuxCreate() failed";
+            goto done;
+        }
+
+        if (ctx->rights || ctx->desc) {
+            size_t siz = 0;
+            uint8_t *d = __xmlman_ConstructXMPWithRDFDescription(ctx->title, ctx->creator, ctx->desc, ctx->rights, ctx->creationtime, &siz);
+            if (siz < 1 || !d) {
+                lib.WebPMuxDelete(mux);
+                error = "Failed to construct XMP data";
+                goto done;
+            }
+
+            WebPData xmp_data = { d, siz };
+            muxErr = lib.WebPMuxSetChunk(mux, "XMP ", &xmp_data, 1);
+            if (muxErr != WEBP_MUX_OK) {
+                lib.WebPMuxDelete(mux);
+                SDL_free(d);
+                error = "WebPMuxSetChunk() failed for XMP data";
+                goto done;
+            }
+
+            SDL_free((void *)d);
+        }
+
+        muxErr = lib.WebPMuxAssemble(mux, &data);
+        if (muxErr != WEBP_MUX_OK) {
+            lib.WebPMuxDelete(mux);
+            error = "WebPMuxAssemble() failed";
+            goto done;
+        }
     }
 
     if (SDL_WriteIO(encoder->dst, data.bytes, data.size) != data.size) {
@@ -880,6 +1025,9 @@ static bool IMG_CloseWEBPAnimation(IMG_AnimationEncoder *encoder)
 done:
     if (data.bytes) {
         lib.WebPFree((void *)data.bytes);
+    }
+    if (mux) {
+        lib.WebPMuxDelete(mux);
     }
     if (ctx->encoder) {
         lib.WebPAnimEncoderDelete(ctx->encoder);
@@ -895,8 +1043,6 @@ done:
 
 bool IMG_CreateWEBPAnimationEncoder(IMG_AnimationEncoder *encoder, SDL_PropertiesID props)
 {
-    (void)props;
-
     if (!IMG_InitWEBP()) {
         return false;
     }
@@ -927,6 +1073,20 @@ bool IMG_CreateWEBPAnimationEncoder(IMG_AnimationEncoder *encoder, SDL_Propertie
         SDL_free(ctx);
         return SDL_SetError("WebPValidateConfig() failed");
     }
+
+    bool ignoreProps = SDL_GetBooleanProperty(props, IMG_PROP_ANIMATION_IGNORE_PROPS_BOOLEAN, false);
+    if (!ignoreProps) {
+        ctx->loop_count = (int)SDL_GetNumberProperty(props, IMG_PROP_ANIMATION_LOOP_COUNT_NUMBER, 0);
+        if (ctx->loop_count < 0) {
+            ctx->loop_count = 0;
+        }
+        ctx->desc = SDL_GetStringProperty(props, IMG_PROP_ANIMATION_DESCRIPTION_STRING, NULL);
+        ctx->rights = SDL_GetStringProperty(props, IMG_PROP_ANIMATION_COPYRIGHT_STRING, NULL);
+        ctx->title = SDL_GetStringProperty(props, IMG_PROP_ANIMATION_TITLE_STRING, NULL);
+        ctx->creator = SDL_GetStringProperty(props, IMG_PROP_ANIMATION_AUTHOR_STRING, NULL);
+        ctx->creationtime = SDL_GetStringProperty(props, IMG_PROP_ANIMATION_CREATION_TIME_STRING, NULL);
+    }
+
     return true;
 }
 

--- a/src/SDL_image.sym
+++ b/src/SDL_image.sym
@@ -82,5 +82,6 @@ SDL3_image_0.0.0 {
     IMG_GetAnimationDecoderFrame;
     IMG_ResetAnimationDecoder;
     IMG_CloseAnimationDecoder;
+    IMG_GetAnimationDecoderProperties;
   local: *;
 };

--- a/src/xmlman.c
+++ b/src/xmlman.c
@@ -1,0 +1,256 @@
+#include <SDL3/SDL.h>
+
+static const char* GetXMLContentFromTag(const uint8_t * data, size_t len, const char* tag) {
+    if (!data || !tag || len == 0) {
+        return NULL;
+    }
+
+    const char* xml_data = (const char*)data;
+    const char* main_tag_start = NULL;
+    const char* main_tag_end = NULL;
+    const char* tag_search_start = xml_data;
+
+    while ((tag_search_start = SDL_strstr(tag_search_start, "<")) != NULL) {
+        const char* tag_name_start = tag_search_start + 1;
+        while (SDL_isspace(*tag_name_start)) {
+            tag_name_start++;
+        }
+        if (SDL_strncmp(tag_name_start, tag, SDL_strlen(tag)) == 0) {
+            const char* tag_end_brace = SDL_strstr(tag_name_start, ">");
+            if (tag_end_brace) {
+                main_tag_start = tag_end_brace + 1;
+                break;
+            }
+        }
+        tag_search_start++;
+    }
+    if (!main_tag_start) {
+        return NULL;
+    }
+
+    char end_tag_str[256];
+    SDL_snprintf(end_tag_str, sizeof(end_tag_str), "</%s>", tag);
+    main_tag_end = SDL_strstr(main_tag_start, end_tag_str);
+    if (!main_tag_end) {
+        return NULL;
+    }
+
+    const char* alt_start = SDL_strstr(main_tag_start, "<rdf:Alt>");
+    if (alt_start && alt_start < main_tag_end) {
+        const char* li_start = alt_start;
+        const char* fallback_content_start = NULL;
+        const char* fallback_content_end = NULL;
+        while ((li_start = SDL_strstr(li_start, "<rdf:li")) != NULL && li_start < main_tag_end) {
+            const char* content_start = SDL_strstr(li_start, ">");
+            if (!content_start) {
+                li_start++;
+                continue;
+            }
+            content_start++;
+            const char* li_end = SDL_strstr(content_start, "</rdf:li>");
+            if (!li_end) {
+                 li_start++;
+                 continue;
+            }
+            const char* default_lang_attr = SDL_strstr(li_start, "xml:lang=\"x-default\"");
+            if (default_lang_attr && default_lang_attr < content_start) {
+                size_t content_len = li_end - content_start;
+                char* final_content = (char*)SDL_malloc(content_len + 1);
+                if (final_content) {
+                    SDL_strlcpy(final_content, content_start, content_len + 1);
+                }
+                return final_content;
+            }
+            const char* en_us_lang_attr = SDL_strstr(li_start, "xml:lang=\"en-us\"");
+            if (en_us_lang_attr && en_us_lang_attr < content_start) {
+                size_t content_len = li_end - content_start;
+                char* final_content = (char*)SDL_malloc(content_len + 1);
+                if (final_content) {
+                    SDL_strlcpy(final_content, content_start, content_len + 1);
+                }
+                return final_content;
+            }
+            if (!fallback_content_start) {
+                fallback_content_start = content_start;
+                fallback_content_end = li_end;
+            }
+
+            li_start = li_end;
+        }
+
+        if (fallback_content_start) {
+            size_t content_len = fallback_content_end - fallback_content_start;
+            char* final_content = (char*)SDL_malloc(content_len + 1);
+            if (final_content) {
+                SDL_strlcpy(final_content, fallback_content_start, content_len + 1);
+            }
+            return final_content;
+        }
+
+        return NULL;
+    }
+
+    const char* seq_start = SDL_strstr(main_tag_start, "<rdf:Seq>");
+    if (seq_start && seq_start < main_tag_end) {
+        const char* li_start = SDL_strstr(seq_start, "<rdf:li");
+        if (li_start) {
+            const char* content_start = SDL_strstr(li_start, ">");
+            if (content_start) {
+                content_start++;
+                const char* li_end = SDL_strstr(content_start, "</rdf:li>");
+                if (li_end) {
+                    size_t content_len = li_end - content_start;
+                    char* final_content = (char*)SDL_malloc(content_len + 1);
+                    if (final_content) {
+                        SDL_strlcpy(final_content, content_start, content_len + 1);
+                    }
+                    return final_content;
+                }
+            }
+        }
+        return NULL;
+    }
+
+    size_t content_len = main_tag_end - main_tag_start;
+    char* final_content = (char*)SDL_malloc(content_len + 1);
+    if (final_content) {
+        SDL_strlcpy(final_content, main_tag_start, content_len + 1);
+    }
+    return final_content;
+}
+
+const char* __xmlman_GetXMPDescription(const uint8_t* data, size_t len)
+{
+    return GetXMLContentFromTag(data, len, "dc:description");
+}
+
+const char *__xmlman_GetXMPCopyright(const uint8_t *data, size_t len)
+{
+    return GetXMLContentFromTag(data, len, "dc:rights");
+}
+
+const char *__xmlman_GetXMPTitle(const uint8_t *data, size_t len)
+{
+    return GetXMLContentFromTag(data, len, "dc:title");
+}
+
+const char *__xmlman_GetXMPCreator(const uint8_t *data, size_t len)
+{
+    return GetXMLContentFromTag(data, len, "dc:creator");
+}
+
+const char *__xmlman_GetXMPCreateDate(const uint8_t *data, size_t len)
+{
+    return GetXMLContentFromTag(data, len, "xmp:CreateDate");
+}
+
+uint8_t *__xmlman_ConstructXMPWithRDFDescription(const char *dctitle, const char *dccreator, const char *dcdescription, const char *dcrights, const char *xmpcreatedate, size_t *outlen)
+{
+    if (!dctitle && !dccreator && !dcdescription && !dcrights && !xmpcreatedate) {
+        if (outlen) {
+            *outlen = 0;
+        }
+        return NULL;
+    }
+
+    const char *header =
+        "<?xpacket begin=\"\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n"
+        "<x:xmpmeta xmlns:x=\"adobe:ns:meta/\">\n"
+        "  <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n"
+        "    <rdf:Description rdf:about=\"\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\" xmlns:xmp=\"http://ns.adobe.com/xap/1.0/\">\n";
+
+    const char *title_prefix =
+        "      <dc:title>\n"
+        "        <rdf:Alt>\n"
+        "          <rdf:li xml:lang=\"x-default\">";
+    const char *title_suffix = "</rdf:li>\n"
+                               "        </rdf:Alt>\n"
+                               "      </dc:title>\n";
+
+    const char *creator_prefix =
+        "      <dc:creator>\n"
+        "        <rdf:Seq>\n"
+        "          <rdf:li>";
+    const char *creator_suffix = "</rdf:li>\n"
+                                 "        </rdf:Seq>\n"
+                                 "      </dc:creator>\n";
+    
+    const char *description_prefix =
+        "      <dc:description>\n"
+        "        <rdf:Alt>\n"
+        "          <rdf:li xml:lang=\"x-default\">";
+    const char *description_suffix = "</rdf:li>\n"
+                                     "        </rdf:Alt>\n"
+                                     "      </dc:description>\n";
+
+    const char *rights_prefix =
+        "      <dc:rights>\n"
+        "        <rdf:Alt>\n"
+        "          <rdf:li xml:lang=\"x-default\">";
+    const char *rights_suffix = "</rdf:li>\n"
+                                "        </rdf:Alt>\n"
+                                "      </dc:rights>\n";
+
+    const char *createdate_prefix = "      <xmp:CreateDate>";
+    const char *createdate_suffix = "</xmp:CreateDate>\n";
+
+    const char *footer =
+        "    </rdf:Description>\n"
+        "  </rdf:RDF>\n"
+        "</x:xmpmeta>\n"
+        "<?xpacket end=\"w\"?>";
+
+    size_t total_size = SDL_strlen(header) +
+                        SDL_strlen(footer) + 1;
+
+    if (dctitle) {
+        total_size += SDL_strlen(title_prefix) + SDL_strlen(dctitle) + SDL_strlen(title_suffix);
+    }
+    if (dccreator) {
+        total_size += SDL_strlen(creator_prefix) + SDL_strlen(dccreator) + SDL_strlen(creator_suffix);
+    }
+    if (dcdescription) {
+        total_size += SDL_strlen(description_prefix) + SDL_strlen(dcdescription) + SDL_strlen(description_suffix);
+    }
+    if (dcrights) {
+        total_size += SDL_strlen(rights_prefix) + SDL_strlen(dcrights) + SDL_strlen(rights_suffix);
+    }
+    if (xmpcreatedate) {
+        total_size += SDL_strlen(createdate_prefix) + SDL_strlen(xmpcreatedate) + SDL_strlen(createdate_suffix);
+    }
+
+    uint8_t *buffer = (uint8_t *)SDL_malloc(total_size);
+    if (!buffer) {
+        if (outlen) {
+            *outlen = 0;
+        }
+        return NULL;
+    }
+
+    char *p = (char *)buffer;
+    p += SDL_snprintf(p, total_size, "%s", header);
+
+    if (dctitle) {
+        p += SDL_snprintf(p, total_size - (p - (char*)buffer), "%s%s%s", title_prefix, dctitle, title_suffix);
+    }
+    if (dccreator) {
+        p += SDL_snprintf(p, total_size - (p - (char*)buffer), "%s%s%s", creator_prefix, dccreator, creator_suffix);
+    }
+    if (dcdescription) {
+        p += SDL_snprintf(p, total_size - (p - (char*)buffer), "%s%s%s", description_prefix, dcdescription, description_suffix);
+    }
+    if (dcrights) {
+        p += SDL_snprintf(p, total_size - (p - (char*)buffer), "%s%s%s", rights_prefix, dcrights, rights_suffix);
+    }
+    if (xmpcreatedate) {
+        p += SDL_snprintf(p, total_size - (p - (char*)buffer), "%s%s%s", createdate_prefix, xmpcreatedate, createdate_suffix);
+    }
+
+    p += SDL_snprintf(p, total_size - (p - (char*)buffer), "%s", footer);
+
+    if (outlen) {
+        *outlen = p - (char*)buffer;
+    }
+
+    return buffer;
+}

--- a/src/xmlman.h
+++ b/src/xmlman.h
@@ -1,0 +1,43 @@
+/*
+  SDL_image:  An example image loading library for use with SDL
+  Copyright (C) 1997-2025 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+/**
+ * This file contains the XML management functions for SDL_image.
+ *
+ * It provides functions to parse and manage XML data, which can be used
+ * for various purposes such as configuration, metadata, or other structured data.
+ */
+
+#ifndef IMG_XML_MAN
+#define IMG_XML_MAN
+#ifdef __cplusplus
+extern "C" {
+#endif
+extern const char *__xmlman_GetXMPDescription(const uint8_t *data, size_t len);
+extern const char *__xmlman_GetXMPCopyright(const uint8_t *data, size_t len);
+extern const char *__xmlman_GetXMPTitle(const uint8_t *data, size_t len);
+extern const char *__xmlman_GetXMPCreator(const uint8_t *data, size_t len);
+extern const char *__xmlman_GetXMPCreateDate(const uint8_t *data, size_t len);
+extern uint8_t *__xmlman_ConstructXMPWithRDFDescription(const char *dctitle, const char *dccreator, const char *dcdescription, const char *dcrights, const char *xmpcreatedate, size_t *outlen);
+#ifdef __cplusplus
+}
+#endif
+#endif /* IMG_XML_MAN */


### PR DESCRIPTION
Introduces the new support to get (decoder) or set (encoder) metadata.

### Added Features
- Added `xmlman.c` and `xmlman.h`, which is simple without any dependency, written by me (no library or license), it simply parses data from XMP and writes data back to XMP from hard-coded XML structures. 
- Added `IMG_PROP_ANIMATION_IGNORE_PROPS_BOOLEAN` for ignoring props in encoder and decoder; some users may want to skip this process entirely. This is what they'd look for.
- Added `IMG_PROP_ANIMATION_DESCRIPTION_STRING` for reading or writing description metadata from decoders and to encoders.
- Added `IMG_PROP_ANIMATION_COPYRIGHT_STRING` for reading or writing copyright metadata from decoders and to encoders.
- Added `IMG_PROP_ANIMATION_TITLE_STRING` for reading or writing copyright metadata from decoders and to encoders.
- Added `IMG_PROP_ANIMATION_AUTHOR_STRING` for reading or writing author/creator metadata from decoders and to encoders
- Added `IMG_PROP_ANIMATION_CREATION_TIME_STRING` for reading or writing image creation time metadata from decoders and to encoders. Some images do not have to be created at the time SDL encodes this; therefore, I exposed it to be set by users if desired as well.
- Added `IMG_PROP_ANIMATION_LOOP_COUNT_NUMBER` for reading or writing the desired loop count for the animation.

### Currently Supported Formats
- WEBP supports all of the well-defined metadata for both decoding and encoding.
- AVIF supports all of the well-defined metadata for both decoding and encoding.
- PNG supports all of the well-defined metadata for both decoding and encoding.
- GIF only supports comment/description and loop count (from the NETSCAPE 2.0 extension) metadata since it's an old format with limited features.

### Tests
Tests still continue, WEBP and AVIF work as expected; however, GIF and PNG remain untested as of 8/11/2025 - 10:04 AM.

Feel free to make recommendations as well as bug fixes.