### PR TITLE
Cumulative fixes for WEBP, AVIF, APNG and GIF Including Timing

### DIFF
--- a/include/SDL3_image/SDL_image.h
+++ b/include/SDL3_image/SDL_image.h
@@ -2631,9 +2631,9 @@ extern SDL_DECLSPEC IMG_AnimationDecoder * SDLCALL IMG_CreateAnimationDecoderWit
 /**
  * Get the properties of an animation decoder.
  *
- * This function returns the properties of the animation decoder, which
- * holds information about the underlying image such as description,
- * copyright text and loop count.
+ * This function returns the properties of the animation decoder, which holds
+ * information about the underlying image such as description, copyright text
+ * and loop count.
  *
  * \param decoder the animation decoder.
  * \returns the properties ID of the animation decoder, or 0 if there are no

--- a/include/SDL3_image/SDL_image.h
+++ b/include/SDL3_image/SDL_image.h
@@ -2505,7 +2505,7 @@ extern SDL_DECLSPEC IMG_AnimationEncoder * SDLCALL IMG_CreateAnimationEncoderWit
  *
  * \param encoder the receiving images.
  * \param surface the surface to add as the next frame in the animation.
- * \param pts the presentation timestamp of the frame, usually in milliseconds
+ * \param delay the duration of the frame, usually in milliseconds
  *            but can be other units if the
  *            `IMG_PROP_ANIMATION_ENCODER_CREATE_TIMEBASE_DENOMINATOR_NUMBER`
  *            property is set when creating the encoder.
@@ -2519,7 +2519,7 @@ extern SDL_DECLSPEC IMG_AnimationEncoder * SDLCALL IMG_CreateAnimationEncoderWit
  * \sa IMG_CreateAnimationEncoderWithProperties
  * \sa IMG_CloseAnimationEncoder
  */
-extern SDL_DECLSPEC bool SDLCALL IMG_AddAnimationEncoderFrame(IMG_AnimationEncoder *encoder, SDL_Surface *surface, Uint64 pts);
+extern SDL_DECLSPEC bool SDLCALL IMG_AddAnimationEncoderFrame(IMG_AnimationEncoder *encoder, SDL_Surface *surface, Uint64 delay);
 
 /**
  * Close an animation encoder, finishing any encoding.
@@ -2631,9 +2631,9 @@ extern SDL_DECLSPEC IMG_AnimationDecoder * SDLCALL IMG_CreateAnimationDecoderWit
 /**
  * Get the properties of an animation decoder.
  *
- * This function returns the properties of the animation decoder, which holds
- * information about the underlying image such as description, copyright text
- * and loop count.
+ * This function returns the properties of the animation decoder, which
+ * holds information about the underlying image such as description,
+ * copyright text and loop count.
  *
  * \param decoder the animation decoder.
  * \returns the properties ID of the animation decoder, or 0 if there are no

--- a/src/IMG_anim_decoder.c
+++ b/src/IMG_anim_decoder.c
@@ -325,7 +325,7 @@ IMG_Animation *IMG_DecodeAsAnimation(SDL_IOStream *src, const char *format, int 
     }
     for (int i = 0; i < anim->count; ++i) {
         anim->frames[i] = frames[i];
-        anim->delays[i] = SDL_round((int)delays[i] * 1000 * decoder->timebase_numerator / decoder->timebase_denominator);
+        anim->delays[i] = SDL_round((int)delays[i] * 1000 * decoder->timebase_numerator / decoder->timebase_denominator); // We do not have decoder here as it's freed above, but that's fine, I think?
     }
 
     SDL_free(frames);

--- a/src/IMG_anim_decoder.c
+++ b/src/IMG_anim_decoder.c
@@ -178,10 +178,10 @@ SDL_PropertiesID IMG_GetAnimationDecoderProperties(IMG_AnimationDecoder *decoder
     return decoder->props;
 }
 
-bool IMG_GetAnimationDecoderFrame(IMG_AnimationDecoder *decoder, SDL_Surface **frame, Uint64 *pts)
+bool IMG_GetAnimationDecoderFrame(IMG_AnimationDecoder *decoder, SDL_Surface **frame, Uint64 *delay)
 {
     SDL_Surface *temp_frame = NULL;
-    Uint64 temp_pts;
+    Uint64 temp_delay;
 
     if (!decoder) {
         return SDL_InvalidParamError("decoder");
@@ -190,14 +190,17 @@ bool IMG_GetAnimationDecoderFrame(IMG_AnimationDecoder *decoder, SDL_Surface **f
     if (!frame) {
         frame = &temp_frame;
     }
-    if (!pts) {
-        pts = &temp_pts;
+    if (!delay) {
+        delay = &temp_delay;
     }
 
-    bool result = decoder->GetNextFrame(decoder, frame, pts);
+    bool result = decoder->GetNextFrame(decoder, frame, delay);
     if (temp_frame) {
         SDL_DestroySurface(temp_frame);
     }
+
+    decoder->accumulated_pts += *delay;
+
     return result;
 }
 
@@ -229,6 +232,14 @@ bool IMG_ResetAnimationDecoder(IMG_AnimationDecoder *decoder)
     }
 
     return decoder->Reset(decoder);
+}
+
+Uint64 IMG_CalculateDelay(IMG_AnimationDecoder* decoder, int delay_num, int delay_den)
+{
+    if (delay_den < 1)
+        delay_den = 100;
+
+    return (Uint64)SDL_round(((double)delay_num / delay_den) * ((double)decoder->timebase_denominator / (double)decoder->timebase_numerator));
 }
 
 IMG_Animation *IMG_DecodeAsAnimation(SDL_IOStream *src, const char *format, int maxFrames)
@@ -314,16 +325,7 @@ IMG_Animation *IMG_DecodeAsAnimation(SDL_IOStream *src, const char *format, int 
     }
     for (int i = 0; i < anim->count; ++i) {
         anim->frames[i] = frames[i];
-
-        if (i < anim->count - 1) {
-            anim->delays[i] = (int)(delays[i + 1] - delays[i]);
-        } else if (i > 0) {
-            // Assuming consistent frame timing
-            anim->delays[i] = anim->delays[i - 1];
-        } else {
-            // Assuming single frame of 60 FPS animation
-            anim->delays[i] = 16;
-        }
+        anim->delays[i] = SDL_round((int)delays[i] * 1000 * decoder->timebase_numerator / decoder->timebase_denominator);
     }
 
     SDL_free(frames);

--- a/src/IMG_anim_decoder.h
+++ b/src/IMG_anim_decoder.h
@@ -29,12 +29,14 @@ struct IMG_AnimationDecoder
     bool closeio;
     int timebase_numerator;
     int timebase_denominator;
+    Uint64 accumulated_pts;
 
-    bool (*GetNextFrame)(IMG_AnimationDecoder *decoder, SDL_Surface** frame, Uint64* pts);
+    bool (*GetNextFrame)(IMG_AnimationDecoder *decoder, SDL_Surface** frame, Uint64* delay);
     bool (*Reset)(IMG_AnimationDecoder *decoder);
     bool (*Close)(IMG_AnimationDecoder *decoder);
 
     IMG_AnimationDecoderContext *ctx;
 };
 
+extern Uint64 IMG_CalculateDelay(IMG_AnimationDecoder *decoder, int delay_num, int delay_den);
 extern IMG_Animation *IMG_DecodeAsAnimation(SDL_IOStream *src, const char *format, int maxFrames);

--- a/src/IMG_anim_encoder.h
+++ b/src/IMG_anim_encoder.h
@@ -29,14 +29,14 @@ struct IMG_AnimationEncoder
     int quality;
     int timebase_numerator;
     int timebase_denominator;
-    Uint64 first_pts;
-    Uint64 last_pts;
+    Uint64 accumulated_pts;
+    Uint64 last_delay;
 
-    bool (*AddFrame)(IMG_AnimationEncoder *encoder, SDL_Surface *surface, Uint64 pts);
+    bool (*AddFrame)(IMG_AnimationEncoder *encoder, SDL_Surface *surface, Uint64 delay);
     bool (*Close)(IMG_AnimationEncoder *encoder);
 
     IMG_AnimationEncoderContext *ctx;
 };
 
-extern int GetStreamPresentationTimestampMS(IMG_AnimationEncoder *encoder, Uint64 pts);
-
+extern Uint64 IMG_GetResolvedDuration(IMG_AnimationEncoder *encoder, Uint64 duration, int factor);
+extern Uint64 IMG_GetCurrentTimestamp(IMG_AnimationEncoder *encoder, int factor);

--- a/src/IMG_avif.c
+++ b/src/IMG_avif.c
@@ -34,7 +34,6 @@
 #ifdef LOAD_AVIF
 
 #include <avif/avif.h>
-#include <limits.h> /* for INT_MAX */
 
 
 /*
@@ -885,9 +884,9 @@ static bool IMG_AnimationDecoderReset_Internal(IMG_AnimationDecoder *decoder)
     return true;
 }
 
-static bool IMG_AnimationDecoderGetNextFrame_Internal(IMG_AnimationDecoder *decoder, SDL_Surface **frame, Uint64 *pts)
+static bool IMG_AnimationDecoderGetNextFrame_Internal(IMG_AnimationDecoder *decoder, SDL_Surface **frame, Uint64 *delay)
 {
-    *pts = 0;
+    *delay = 0;
     *frame = NULL;
 
     IMG_AnimationDecoderContext *ctx = decoder->ctx;
@@ -1020,11 +1019,7 @@ static bool IMG_AnimationDecoderGetNextFrame_Internal(IMG_AnimationDecoder *deco
         SDL_SetSurfaceColorspace(frame_surface, colorspace);
     }
 
-    if (ctx->decoder->imageTiming.timescale > 0) {
-        *pts = (Uint64)ctx->decoder->imageTiming.ptsInTimescales * decoder->timebase_denominator / (ctx->decoder->imageTiming.timescale * decoder->timebase_numerator);
-    } else {
-        *pts = 0;
-    }
+    *delay = ctx->decoder->imageTiming.ptsInTimescales * decoder->timebase_numerator;
 
     ctx->current_frame++;
 
@@ -1076,6 +1071,7 @@ bool IMG_CreateAVIFAnimationDecoder(IMG_AnimationDecoder *decoder, SDL_Propertie
     }
 
     ctx->decoder->strictFlags = AVIF_STRICT_DISABLED;
+    ctx->decoder->timescale = decoder->timebase_denominator;
 
     ctx->ioContext.src = decoder->src;
     ctx->ioContext.start = ctx->start_pos;
@@ -1198,7 +1194,7 @@ struct IMG_AnimationEncoderContext
     const char *createdate;
 };
 
-static bool AnimationEncoder_AddFrame(struct IMG_AnimationEncoder *encoder, SDL_Surface *surface, Uint64 pts)
+static bool AnimationEncoder_AddFrame(struct IMG_AnimationEncoder *encoder, SDL_Surface *surface, Uint64 delay)
 {
     avifImage *image = NULL;
     avifRGBImage rgb;
@@ -1220,12 +1216,7 @@ static bool AnimationEncoder_AddFrame(struct IMG_AnimationEncoder *encoder, SDL_
                    surface->format == SDL_PIXELFORMAT_ABGR64);
     bool hasAlpha = SDL_ISPIXELFORMAT_ALPHA(surface->format);
 
-    double delta_seconds = (double)(!encoder->ctx->first_frame_added ? encoder->first_pts : (pts - encoder->last_pts)) * encoder->timebase_numerator / encoder->timebase_denominator;
-    durationInTimescales = (uint64_t)SDL_round(delta_seconds * encoder->ctx->encoder->timescale);
-    if (durationInTimescales == 0) {
-        durationInTimescales = 1;
-    }
-
+    durationInTimescales = delay * encoder->timebase_numerator;
     colorspace = SDL_GetSurfaceColorspace(surface);
     props = SDL_GetSurfaceProperties(surface);
     maxCLL = (Uint16)SDL_GetNumberProperty(props, SDL_PROP_SURFACE_MAXCLL_NUMBER, 0);
@@ -1607,11 +1598,7 @@ bool IMG_CreateAVIFAnimationEncoder(IMG_AnimationEncoder *encoder, SDL_Propertie
     encoder->ctx->encoder->tileRowsLog2 = 0;
     encoder->ctx->encoder->tileColsLog2 = 0;
 
-    if (encoder->timebase_denominator > 0) {
-        encoder->ctx->encoder->timescale = (uint32_t)encoder->timebase_denominator;
-    } else {
-        encoder->ctx->encoder->timescale = 1000;
-    }
+    encoder->ctx->encoder->timescale = (uint32_t)encoder->timebase_denominator;
 
     bool ignoreProps = SDL_GetBooleanProperty(props, IMG_PROP_METADATA_IGNORE_PROPS_BOOLEAN, false);
     if (!ignoreProps) {


### PR DESCRIPTION
This PR contains fixes for GIF decoding as well as a more robust implementation for timing, converting `PTS` to an internal-use-only field, and exposing frame-based delay instead, which still relies on timebase_numerator and timebase_denominator.

Here are the changes made:
- Remove `limits.h` from `IMG_avif.c` because it was not being used.
- Remove the `last_pts` field in `IMG_anim_encoder`.
- Remove the `first_pts` field in `IMG_anim_encoder`.
- Introduce the `accumulated_pts` field in `IMG_anim_encoder`.
- Introduce the `last_delay` field in `IMG_anim_encoder`.
- Remove the `GetStreamPresentationTimestampMS` function in `IMG_anim_encoder` because it is no longer needed.
- Introduce the `IMG_GetResolvedDuration` function in `IMG_anim_encoder`.
- Introduce the IMG_GetCurrentTimestamp function in `IMG_anim_encoder`.
- Introduce the `accumulated_pts` field in `IMG_anim_decoder`.
- Introduce the `IMG_CalculateDelay` function in `IMG_anim_decoder`.
- Rename all `pts` parameter names to `delay` in both `SDL_image.h` and all other headers/c files for formats and encoders/decoders.
- Change `IMG_gif`, `IMG_webp`, `IMG_avif`, and `IMG_libpng` to use these new delay calculation functions instead of the old, incorrect algorithms.
- Fix the `IMG_AnimationDecoderGetGIFHeader` function in `IMG_gif` where the extension reader wasn't setting back the original position of the stream before handing back to the parser.

This seems to be implemented more robustly than before, resulting in better consistency for our API as well.

### Tests
The tests continues, please do not merge this until you see the line here change with a different message.