### PR TITLE
Add missing compilation files to Xcode project

### DIFF
--- a/Xcode/SDL_image.xcodeproj/project.pbxproj
+++ b/Xcode/SDL_image.xcodeproj/project.pbxproj
@@ -37,6 +37,9 @@
 
 /* Begin PBXBuildFile section */
 		6313BF532785566D00F268AD /* IMG_qoi.c in Sources */ = {isa = PBXBuildFile; fileRef = 6313BF522785566D00F268AD /* IMG_qoi.c */; };
+		8F53A75F2E4CE9080018A272 /* IMG_anim_decoder.c in Sources */ = {isa = PBXBuildFile; fileRef = 8F53A75D2E4CE9080018A272 /* IMG_anim_decoder.c */; };
+		8F53A7602E4CE9080018A272 /* IMG_anim_encoder.c in Sources */ = {isa = PBXBuildFile; fileRef = 8F53A75E2E4CE9080018A272 /* IMG_anim_encoder.c */; };
+		8F53A7622E4CEE920018A272 /* IMG_libpng.c in Sources */ = {isa = PBXBuildFile; fileRef = 8F53A7612E4CEE920018A272 /* IMG_libpng.c */; };
 		AA50AA471F9C7C50003B9C0C /* IMG_svg.c in Sources */ = {isa = PBXBuildFile; fileRef = AA50AA461F9C7C50003B9C0C /* IMG_svg.c */; };
 		AA579DF2161C07E6005F809B /* IMG_bmp.c in Sources */ = {isa = PBXBuildFile; fileRef = AA579DE2161C07E6005F809B /* IMG_bmp.c */; };
 		AA579DF4161C07E7005F809B /* IMG_gif.c in Sources */ = {isa = PBXBuildFile; fileRef = AA579DE3161C07E6005F809B /* IMG_gif.c */; };
@@ -64,7 +67,6 @@
 		F354743E2828CA66007E9EDA /* IMG_jxl.c in Sources */ = {isa = PBXBuildFile; fileRef = F354743B2828CA66007E9EDA /* IMG_jxl.c */; };
 		F35475FD2829BAF9007E9EDA /* IMG_avif.c in Sources */ = {isa = PBXBuildFile; fileRef = F35475FC2829BAF9007E9EDA /* IMG_avif.c */; };
 		F382070E284EF58C004DD584 /* CMake in Resources */ = {isa = PBXBuildFile; fileRef = F3820707284EF58C004DD584 /* CMake */; };
-		F382FBDE2E3D7BEF004C6137 /* IMG_anim.c in Sources */ = {isa = PBXBuildFile; fileRef = F382FBDD2E3D7BEF004C6137 /* IMG_anim.c */; };
 		F3E1AAEB281CBABD00740E39 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3E1AAEA281CBABD00740E39 /* CoreGraphics.framework */; platformFilters = (ios, tvos, ); };
 		F3E1AAEC281CBB1F00740E39 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3E1AAE8281CBA7B00740E39 /* ImageIO.framework */; platformFilters = (ios, tvos, ); };
 		F3E1AAEE281CBD9F00740E39 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3E1AAED281CBD9F00740E39 /* UIKit.framework */; platformFilters = (ios, tvos, ); };
@@ -156,6 +158,9 @@
 		1014BAEA010A4B677F000001 /* SDL_image.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = SDL_image.h; path = ../include/SDL3_image/SDL_image.h; sourceTree = SOURCE_ROOT; };
 		61F85449145A19BC002CA294 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		6313BF522785566D00F268AD /* IMG_qoi.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = IMG_qoi.c; path = ../src/IMG_qoi.c; sourceTree = "<group>"; };
+		8F53A75D2E4CE9080018A272 /* IMG_anim_decoder.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = IMG_anim_decoder.c; path = ../src/IMG_anim_decoder.c; sourceTree = SOURCE_ROOT; };
+		8F53A75E2E4CE9080018A272 /* IMG_anim_encoder.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = IMG_anim_encoder.c; path = ../src/IMG_anim_encoder.c; sourceTree = SOURCE_ROOT; };
+		8F53A7612E4CEE920018A272 /* IMG_libpng.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = IMG_libpng.c; path = ../src/IMG_libpng.c; sourceTree = SOURCE_ROOT; };
 		AA50AA461F9C7C50003B9C0C /* IMG_svg.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = IMG_svg.c; path = ../src/IMG_svg.c; sourceTree = "<group>"; };
 		AA579DE2161C07E6005F809B /* IMG_bmp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = IMG_bmp.c; path = ../src/IMG_bmp.c; sourceTree = "<group>"; };
 		AA579DE3161C07E6005F809B /* IMG_gif.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = IMG_gif.c; path = ../src/IMG_gif.c; sourceTree = "<group>"; };
@@ -186,7 +191,6 @@
 		F35475FC2829BAF9007E9EDA /* IMG_avif.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = IMG_avif.c; path = ../src/IMG_avif.c; sourceTree = "<group>"; };
 		F3547625282AE1C6007E9EDA /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = config.xcconfig; sourceTree = "<group>"; };
 		F3820707284EF58C004DD584 /* CMake */ = {isa = PBXFileReference; lastKnownFileType = folder; path = CMake; sourceTree = "<group>"; };
-		F382FBDD2E3D7BEF004C6137 /* IMG_anim.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = IMG_anim.c; path = ../src/IMG_anim.c; sourceTree = SOURCE_ROOT; };
 		F3D87D15281EA88F005DA540 /* webp.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = webp.xcodeproj; path = webp/webp.xcodeproj; sourceTree = "<group>"; };
 		F3E1AAE8281CBA7B00740E39 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		F3E1AAEA281CBABD00740E39 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -251,7 +255,8 @@
 			children = (
 				AA579DF1161C07E6005F809B /* IMG.c */,
 				AA579DE4161C07E6005F809B /* IMG_ImageIO.m */,
-				F382FBDD2E3D7BEF004C6137 /* IMG_anim.c */,
+				8F53A75D2E4CE9080018A272 /* IMG_anim_decoder.c */,
+				8F53A75E2E4CE9080018A272 /* IMG_anim_encoder.c */,
 				F35475FC2829BAF9007E9EDA /* IMG_avif.c */,
 				AA579DE2161C07E6005F809B /* IMG_bmp.c */,
 				AA579DE3161C07E6005F809B /* IMG_gif.c */,
@@ -260,6 +265,7 @@
 				AA579DE6161C07E6005F809B /* IMG_lbm.c */,
 				AA579DE7161C07E6005F809B /* IMG_pcx.c */,
 				AA579DE8161C07E6005F809B /* IMG_png.c */,
+				8F53A7612E4CEE920018A272 /* IMG_libpng.c */,
 				AA579DE9161C07E6005F809B /* IMG_pnm.c */,
 				6313BF522785566D00F268AD /* IMG_qoi.c */,
 				F31094C2282AE42D008EF641 /* IMG_stb.c */,
@@ -558,13 +564,15 @@
 				AA579DF8161C07E7005F809B /* IMG_jpg.c in Sources */,
 				AA579DFA161C07E7005F809B /* IMG_lbm.c in Sources */,
 				AA579DFC161C07E7005F809B /* IMG_pcx.c in Sources */,
+				8F53A7622E4CEE920018A272 /* IMG_libpng.c in Sources */,
 				AA579DFE161C07E7005F809B /* IMG_png.c in Sources */,
 				AA579E00161C07E7005F809B /* IMG_pnm.c in Sources */,
 				AA579E02161C07E7005F809B /* IMG_tga.c in Sources */,
 				F35475FD2829BAF9007E9EDA /* IMG_avif.c in Sources */,
-				F382FBDE2E3D7BEF004C6137 /* IMG_anim.c in Sources */,
 				AA579E04161C07E7005F809B /* IMG_tif.c in Sources */,
 				AA579E06161C07E7005F809B /* IMG_webp.c in Sources */,
+				8F53A75F2E4CE9080018A272 /* IMG_anim_decoder.c in Sources */,
+				8F53A7602E4CE9080018A272 /* IMG_anim_encoder.c in Sources */,
 				AA579E08161C07E7005F809B /* IMG_xcf.c in Sources */,
 				AA579E0A161C07E7005F809B /* IMG_xpm.c in Sources */,
 				F354743E2828CA66007E9EDA /* IMG_jxl.c in Sources */,


### PR DESCRIPTION
Fixes https://github.com/libsdl-org/SDL_image/issues/607

Added/changed in https://github.com/libsdl-org/SDL_image/pull/600, the files were not present in the Xcode project causing iOS builds to fail.

Passing run: https://github.com/smoogipoo/SDL3-CS/actions/runs/16942815791