### PR TITLE
miniz: Avoid arithmetic on null pointer to avoid UBSan

### DIFF
--- a/src/miniz.h
+++ b/src/miniz.h
@@ -2612,7 +2612,7 @@ static mz_bool tdefl_compress_normal(tdefl_compressor *d)
       mz_uint dst_pos = (d->m_lookahead_pos + d->m_lookahead_size) & TDEFL_LZ_DICT_SIZE_MASK, ins_pos = d->m_lookahead_pos + d->m_lookahead_size - 2;
       mz_uint hash = (d->m_dict[ins_pos & TDEFL_LZ_DICT_SIZE_MASK] << TDEFL_LZ_HASH_SHIFT) ^ d->m_dict[(ins_pos + 1) & TDEFL_LZ_DICT_SIZE_MASK];
       mz_uint num_bytes_to_process = (mz_uint)MZ_MIN(src_buf_left, TDEFL_MAX_MATCH_LEN - d->m_lookahead_size);
-      const mz_uint8 *pSrc_end = pSrc + num_bytes_to_process;
+      const mz_uint8 *pSrc_end = pSrc ? pSrc + num_bytes_to_process : pSrc;
       src_buf_left -= num_bytes_to_process;
       d->m_lookahead_size += num_bytes_to_process;
       while (pSrc != pSrc_end)


### PR DESCRIPTION
Clang/LLVM's undefined behavior sanitizer triggers a crash when an offset (even zero) is added to a null pointer. I used a debugger to confirm that `num_bytes_to_process` is zero, which means there should be no change in behavior.

The next revision of the C language standard (C2Y) allows zero-length operations on null pointers, but we may be waiting a couple years before it is finalized.

See: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3322.pdf