### PR TITLE
Fix for Memory Leaks and Comprehensive Impl of Metadata

### DIFF
--- a/src/IMG_anim_encoder.c
+++ b/src/IMG_anim_encoder.c
@@ -195,3 +195,17 @@ Uint64 IMG_GetEncoderDuration(IMG_AnimationEncoder *encoder, Uint64 duration, Ui
     encoder->accumulated_pts += duration;
     return value;
 }
+
+bool IMG_HasMetadata(SDL_PropertiesID props)
+{
+    if (!props) {
+        return false;
+    }
+
+    return SDL_HasProperty(props, IMG_PROP_METADATA_LOOP_COUNT_NUMBER) ||
+           SDL_HasProperty(props, IMG_PROP_METADATA_AUTHOR_STRING) ||
+           SDL_HasProperty(props, IMG_PROP_METADATA_COPYRIGHT_STRING) ||
+           SDL_HasProperty(props, IMG_PROP_METADATA_CREATION_TIME_STRING) ||
+           SDL_HasProperty(props, IMG_PROP_METADATA_DESCRIPTION_STRING) ||
+           SDL_HasProperty(props, IMG_PROP_METADATA_TITLE_STRING);
+}

--- a/src/IMG_anim_encoder.h
+++ b/src/IMG_anim_encoder.h
@@ -39,3 +39,4 @@ struct IMG_AnimationEncoder
 
 extern Uint64 IMG_TimebaseDuration(Uint64 pts, Uint64 duration, Uint64 src_numerator, Uint64 src_denominator, Uint64 dst_numerator, Uint64 dst_denominator);
 extern Uint64 IMG_GetEncoderDuration(IMG_AnimationEncoder *encoder, Uint64 duration, Uint64 timebase_denominator);
+extern bool IMG_HasMetadata(SDL_PropertiesID props);

--- a/src/IMG_webp.c
+++ b/src/IMG_webp.c
@@ -601,18 +601,23 @@ bool IMG_CreateWEBPAnimationDecoder(IMG_AnimationDecoder *decoder, SDL_Propertie
                 const char *createdate = __xmlman_GetXMPCreateDate(xmp_iter.chunk.bytes, xmp_iter.chunk.size);
                 if (desc) {
                     SDL_SetStringProperty(decoder->props, IMG_PROP_METADATA_DESCRIPTION_STRING, desc);
+                    SDL_free((void *)desc);
                 }
                 if (rights) {
                     SDL_SetStringProperty(decoder->props, IMG_PROP_METADATA_COPYRIGHT_STRING, rights);
+                    SDL_free((void *)rights);
                 }
                 if (title) {
                     SDL_SetStringProperty(decoder->props, IMG_PROP_METADATA_TITLE_STRING, title);
+                    SDL_free((void *)title);
                 }
                 if (creator) {
                     SDL_SetStringProperty(decoder->props, IMG_PROP_METADATA_AUTHOR_STRING, creator);
+                    SDL_free((void *)creator);
                 }
                 if (createdate) {
                     SDL_SetStringProperty(decoder->props, IMG_PROP_METADATA_CREATION_TIME_STRING, createdate);
+                    SDL_free((void *)createdate);
                 }
             }
             lib.WebPDemuxReleaseChunkIterator(&xmp_iter);
@@ -836,13 +841,8 @@ struct IMG_AnimationEncoderContext
 {
     WebPAnimEncoder *encoder;
     WebPConfig config;
-    const char *desc;
-    const char *rights;
-    const char *title;
-    const char *creator;
-    const char *creationtime;
     int timestamp;
-    int loop_count;
+    SDL_PropertiesID metadata;
 };
 
 static bool IMG_AddWEBPAnimationFrame(IMG_AnimationEncoder *encoder, SDL_Surface *surface, Uint64 duration)
@@ -920,7 +920,7 @@ static bool IMG_CloseWEBPAnimation(IMG_AnimationEncoder *encoder)
         goto done;
     }
 
-    if (!ctx->rights && !ctx->desc && !ctx->creationtime && !ctx->creator && !ctx->title && ctx->loop_count == 0) {
+    if (!IMG_HasMetadata(ctx->metadata)) {
         if (!lib.WebPAnimEncoderAssemble(ctx->encoder, &data)) {
             error = "WebPAnimEncoderAssemble() failed";
             goto done;
@@ -950,30 +950,28 @@ static bool IMG_CloseWEBPAnimation(IMG_AnimationEncoder *encoder)
             error = "WebPMuxGetAnimationParams() failed";
             goto done;
         }
-        params.loop_count = ctx->loop_count;
+        params.loop_count = (int)SDL_max(SDL_GetNumberProperty(ctx->metadata, IMG_PROP_METADATA_LOOP_COUNT_NUMBER, 0), 0);
         muxErr = lib.WebPMuxSetAnimationParams(mux, &params);
         if (muxErr != WEBP_MUX_OK) {
             error = "WebPMuxSetAnimationParams() failed";
             goto done;
         }
 
-        if (ctx->rights || ctx->desc || ctx->title || ctx->creator || ctx->creationtime) {
-            size_t siz = 0;
-            uint8_t *d = __xmlman_ConstructXMPWithRDFDescription(ctx->title, ctx->creator, ctx->desc, ctx->rights, ctx->creationtime, &siz);
-            if (siz < 1 || !d) {
-                error = "Failed to construct XMP data";
-                goto done;
-            }
-            WebPData xmp_data = { d, siz };
-            muxErr = lib.WebPMuxSetChunk(mux, "XMP ", &xmp_data, 1);
-            if (muxErr != WEBP_MUX_OK) {
-                SDL_free(d);
-                error = "WebPMuxSetChunk() failed for XMP data";
-                goto done;
-            }
-
-            SDL_free((void *)d);
+        size_t siz = 0;
+        uint8_t *d = __xmlman_ConstructXMPWithRDFDescription(SDL_GetStringProperty(ctx->metadata, IMG_PROP_METADATA_TITLE_STRING, NULL), SDL_GetStringProperty(ctx->metadata, IMG_PROP_METADATA_AUTHOR_STRING, NULL), SDL_GetStringProperty(ctx->metadata, IMG_PROP_METADATA_DESCRIPTION_STRING, NULL), SDL_GetStringProperty(ctx->metadata, IMG_PROP_METADATA_COPYRIGHT_STRING, NULL), SDL_GetStringProperty(ctx->metadata, IMG_PROP_METADATA_CREATION_TIME_STRING, NULL), &siz);
+        if (siz < 1 || !d) {
+            error = "Failed to construct XMP data";
+            goto done;
         }
+        WebPData xmp_data = { d, siz };
+        muxErr = lib.WebPMuxSetChunk(mux, "XMP ", &xmp_data, 1);
+        if (muxErr != WEBP_MUX_OK) {
+            SDL_free(d);
+            error = "WebPMuxSetChunk() failed for XMP data";
+            goto done;
+        }
+
+        SDL_free((void *)d);
 
         muxErr = lib.WebPMuxAssemble(mux, &data);
         if (muxErr != WEBP_MUX_OK) {
@@ -988,6 +986,11 @@ static bool IMG_CloseWEBPAnimation(IMG_AnimationEncoder *encoder)
     }
 
 done:
+    if (ctx->metadata) {
+        SDL_DestroyProperties(ctx->metadata);
+        ctx->metadata = 0;
+    }
+
     if (data.bytes) {
         lib.WebPFree((void *)data.bytes);
     }
@@ -1041,15 +1044,18 @@ bool IMG_CreateWEBPAnimationEncoder(IMG_AnimationEncoder *encoder, SDL_Propertie
 
     bool ignoreProps = SDL_GetBooleanProperty(props, IMG_PROP_METADATA_IGNORE_PROPS_BOOLEAN, false);
     if (!ignoreProps) {
-        ctx->loop_count = (int)SDL_GetNumberProperty(props, IMG_PROP_METADATA_LOOP_COUNT_NUMBER, 0);
-        if (ctx->loop_count < 0) {
-            ctx->loop_count = 0;
+        ctx->metadata = SDL_CreateProperties();
+        if (!ctx->metadata) {
+            SDL_free(ctx);
+            return SDL_SetError("Failed to create properties for WebP metadata");
         }
-        ctx->desc = SDL_GetStringProperty(props, IMG_PROP_METADATA_DESCRIPTION_STRING, NULL);
-        ctx->rights = SDL_GetStringProperty(props, IMG_PROP_METADATA_COPYRIGHT_STRING, NULL);
-        ctx->title = SDL_GetStringProperty(props, IMG_PROP_METADATA_TITLE_STRING, NULL);
-        ctx->creator = SDL_GetStringProperty(props, IMG_PROP_METADATA_AUTHOR_STRING, NULL);
-        ctx->creationtime = SDL_GetStringProperty(props, IMG_PROP_METADATA_CREATION_TIME_STRING, NULL);
+
+        if (!SDL_CopyProperties(props, ctx->metadata)) {
+            SDL_DestroyProperties(ctx->metadata);
+            ctx->metadata = 0;
+            SDL_free(ctx);
+            return SDL_SetError("Failed to copy properties for WebP metadata");
+        }
     }
 
     return true;

--- a/test/AnimationTestSuite.c
+++ b/test/AnimationTestSuite.c
@@ -3,7 +3,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <SDL3/SDL.h>
-#include <SDL_image.h>
+#include <SDL3_image/SDL_image.h>
 
 #define MAX_METADATA 6
 

--- a/test/AnimationTestSuite.c
+++ b/test/AnimationTestSuite.c
@@ -3,7 +3,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <SDL3/SDL.h>
-#include <SDL3_image/SDL_image.h>
+#include <SDL_image.h>
 
 #define MAX_METADATA 6
 
@@ -19,7 +19,7 @@ typedef struct {
 typedef struct
 {
     const char *metadata;
-    void *value;
+    const void *value;
     SDL_PropertyType type;
 } MetadataInfo;
 
@@ -28,11 +28,21 @@ typedef struct {
     MetadataInfo availableMetadata[MAX_METADATA];
 } FormatInfo;
 
+static const int default_loop_count = 1;
+#define DEFAULT_TITLE "Lorem ipsum dolor sit amet"
+#define DEFAULT_AUTHOR "consectetur adipiscing elit"
+#define DEFAULT_DESCRIPTION "sed do eiusmod tempor <xml escape test> incididunt ut labore et dolore magna aliqua"
+#define DEFAULT_CREATION_TIME "Ut enim ad minim veniam"
+#define DEFAULT_COPYRIGHT     "quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat"
+
 static const FormatInfo formatInfo[] = {
-    { "PNG", { { IMG_PROP_METADATA_TITLE_STRING, "Test Animation", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_AUTHOR_STRING, "Xen", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_DESCRIPTION_STRING, "Love SDL", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_LOOP_COUNT_NUMBER, (void*)(Sint64)1, SDL_PROPERTY_TYPE_NUMBER }, { IMG_PROP_METADATA_CREATION_TIME_STRING, "2077", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_COPYRIGHT_STRING, "Copyright 2077 SDL_image Test Suite", SDL_PROPERTY_TYPE_STRING } } },
-    { "GIF", { { IMG_PROP_METADATA_DESCRIPTION_STRING, "Love SDL", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_LOOP_COUNT_NUMBER, (void*)(Sint64)1, SDL_PROPERTY_TYPE_NUMBER } } },
-    { "WEBP", { { IMG_PROP_METADATA_TITLE_STRING, "Test Animation", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_AUTHOR_STRING, "Xen", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_DESCRIPTION_STRING, "Love SDL", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_LOOP_COUNT_NUMBER, (void*)(Sint64)1, SDL_PROPERTY_TYPE_NUMBER }, { IMG_PROP_METADATA_CREATION_TIME_STRING, "2077", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_COPYRIGHT_STRING, "Copyright 2077 SDL_image Test Suite", SDL_PROPERTY_TYPE_STRING } } },
-    { "AVIFS", { { IMG_PROP_METADATA_TITLE_STRING, "Test Animation", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_AUTHOR_STRING, "Xen", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_DESCRIPTION_STRING, "Love SDL", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_LOOP_COUNT_NUMBER, (void*)(Sint64)1, SDL_PROPERTY_TYPE_NUMBER }, { IMG_PROP_METADATA_CREATION_TIME_STRING, "2077", SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_COPYRIGHT_STRING, "Copyright 2077 SDL_image Test Suite", SDL_PROPERTY_TYPE_STRING } } },
+    { "PNG", { { IMG_PROP_METADATA_TITLE_STRING, (const void*)DEFAULT_TITLE, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_AUTHOR_STRING, (const void*)DEFAULT_AUTHOR, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_DESCRIPTION_STRING, (const void*)DEFAULT_DESCRIPTION, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_LOOP_COUNT_NUMBER, (const void *)&default_loop_count, SDL_PROPERTY_TYPE_NUMBER }, { IMG_PROP_METADATA_CREATION_TIME_STRING, (const void*)DEFAULT_CREATION_TIME, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_COPYRIGHT_STRING, (const void*)DEFAULT_COPYRIGHT, SDL_PROPERTY_TYPE_STRING } } },
+
+    { "GIF", { { IMG_PROP_METADATA_DESCRIPTION_STRING, (const void*)DEFAULT_DESCRIPTION, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_LOOP_COUNT_NUMBER, (const void *)&default_loop_count, SDL_PROPERTY_TYPE_NUMBER } } },
+
+    { "WEBP", { { IMG_PROP_METADATA_TITLE_STRING, (const void*)DEFAULT_TITLE, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_AUTHOR_STRING, (const void*)DEFAULT_AUTHOR, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_DESCRIPTION_STRING, (const void*)DEFAULT_DESCRIPTION, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_LOOP_COUNT_NUMBER, (const void *)&default_loop_count, SDL_PROPERTY_TYPE_NUMBER }, { IMG_PROP_METADATA_CREATION_TIME_STRING, (const void*)DEFAULT_CREATION_TIME, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_COPYRIGHT_STRING, (const void*)DEFAULT_COPYRIGHT, SDL_PROPERTY_TYPE_STRING } } },
+
+    { "AVIFS", { { IMG_PROP_METADATA_TITLE_STRING, (const void*)DEFAULT_TITLE, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_AUTHOR_STRING, (const void*)DEFAULT_AUTHOR, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_DESCRIPTION_STRING, (const void*)DEFAULT_DESCRIPTION, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_LOOP_COUNT_NUMBER, (const void *)&default_loop_count, SDL_PROPERTY_TYPE_NUMBER }, { IMG_PROP_METADATA_CREATION_TIME_STRING, (const void*)DEFAULT_CREATION_TIME, SDL_PROPERTY_TYPE_STRING }, { IMG_PROP_METADATA_COPYRIGHT_STRING, (const void*)DEFAULT_COPYRIGHT, SDL_PROPERTY_TYPE_STRING } } },
 };
 
 static const char *inputImages[] = { "rgbrgb.png", "rgbrgb.gif", "rgbrgb.webp", "rgbrgb.avifs" };
@@ -612,7 +622,7 @@ int main(int argc, char **argv)
                 if (metadata->type == SDL_PROPERTY_TYPE_BOOLEAN) {
                     bool propValue = SDL_GetBooleanProperty(decodedProps, propName, false);
                     printf("Decoded Property %s: %s\n", propName, propValue ? "true" : "false");
-                    bool expectedValue = *(bool *)metadata->value;
+                    const bool expectedValue = *(const bool *)metadata->value;
                     if (propValue != expectedValue) {
                         fprintf(stderr, "ERROR: Decoded boolean property %s does not match expected value. Expected: %s, Got: %s\n",
                                 propName, expectedValue ? "true" : "false", propValue ? "true" : "false");
@@ -624,7 +634,7 @@ int main(int argc, char **argv)
                 } else if (metadata->type == SDL_PROPERTY_TYPE_NUMBER) {
                     Sint64 propValue = SDL_GetNumberProperty(decodedProps, propName, 0);
                     printf("Decoded Property %s: %" SDL_PRIs64 "\n", propName, propValue);
-                    Sint64 expectedValue = *(Sint64 *)metadata->value;
+                    const Sint64 expectedValue = *(const Sint64 *)metadata->value;
                     if (propValue != expectedValue) {
                         fprintf(stderr, "ERROR: Decoded number property %s does not match expected value. Expected: %" SDL_PRIs64 ", Got: %" SDL_PRIs64 "\n",
                                 propName, expectedValue, propValue);


### PR DESCRIPTION
Fixes memory leak in AVIF, WEBP, GIF, and PNG where strings were assigned to SDL props but weren't freed after the assignment.
This also fixes metadata definitions in the animation test suite, completes the implementation @sezero started.

The metadata strings in the test suite have been changed with more robust texts to include most characters, as well as XML escaping tests.