### PR TITLE
Enable blending by default for PNGs with alpha palettes

### DIFF
--- a/src/IMG_libpng.c
+++ b/src/IMG_libpng.c
@@ -475,6 +475,7 @@ static bool LIBPNG_LoadPNG_IO_Internal(SDL_IOStream *src, struct png_load_vars *
                 for (int i = 0; i < vars->num_trans && i < vars->num_palette; i++) {
                     palette->colors[i].a = vars->trans[i];
                 }
+                SDL_SetSurfaceBlendMode(vars->surface, SDL_BLENDMODE_BLEND);
             }
 
             SDL_SetSurfacePalette(vars->surface, palette);


### PR DESCRIPTION
This matches the default behaviour for true colour surfaces, and ensures that the transparency is displayed correctly in `showimage`.