### PR TITLE
Enhance xmlman

### DIFF
--- a/src/xmlman.c
+++ b/src/xmlman.c
@@ -273,10 +273,11 @@ static char* __xmlman_GetXMLContentFromTag(const char* data, size_t len, const c
             
             if (default_lang || en_us_lang) {
                 size_t content_len = li_end - li_content_start;
-                char* result = (char*)SDL_malloc(content_len + 1);
+                ++content_len;
+                char* result = (char*)SDL_malloc(content_len);
                 if (result) {
-                    SDL_memcpy(result, li_content_start, content_len);
-                    result[content_len] = '\0';
+                    SDL_memcpy(result, li_content_start, content_len - 1);
+                    result[content_len - 1] = '\0';
                     __xmlman_unescape_inplace(result, content_len);
                 }
                 return result;
@@ -303,10 +304,11 @@ static char* __xmlman_GetXMLContentFromTag(const char* data, size_t len, const c
                 return NULL;
             }
 
-            char* result = (char*)SDL_malloc(fallback_len + 1);
+            ++fallback_len;
+            char* result = (char*)SDL_malloc(fallback_len);
             if (result) {
-                SDL_memcpy(result, fallback_content, fallback_len);
-                result[fallback_len] = '\0';
+                SDL_memcpy(result, fallback_content, fallback_len - 1);
+                result[fallback_len - 1] = '\0';
                 __xmlman_unescape_inplace(result, fallback_len);
             }
             return result;
@@ -333,11 +335,11 @@ static char* __xmlman_GetXMLContentFromTag(const char* data, size_t len, const c
                         return NULL;
                     }
 
-                    size_t content_len = li_end - li_content_start;
-                    char* result = (char*)SDL_malloc(content_len + 1);
+                    size_t content_len = (li_end - li_content_start) + 1;
+                    char* result = (char*)SDL_malloc(content_len);
                     if (result) {
-                        SDL_memcpy(result, li_content_start, content_len);
-                        result[content_len] = '\0';
+                        SDL_memcpy(result, li_content_start, content_len - 1);
+                        result[content_len - 1] = '\0';
                         __xmlman_unescape_inplace(result, content_len);
                     }
                     return result;
@@ -357,11 +359,11 @@ static char* __xmlman_GetXMLContentFromTag(const char* data, size_t len, const c
         return NULL;
     }
 
-    size_t content_len = content_end - content_start;
-    char* result = (char*)SDL_malloc(content_len + 1);
+    size_t content_len = (content_end - content_start) + 1;
+    char* result = (char*)SDL_malloc(content_len);
     if (result) {
-        SDL_memcpy(result, content_start, content_len);
-        result[content_len] = '\0';
+        SDL_memcpy(result, content_start, content_len - 1);
+        result[content_len - 1] = '\0';
         __xmlman_unescape_inplace(result, content_len);
     }
     return result;


### PR DESCRIPTION
Created to fix #627 and to enhance the overall code of XML Manager.

Here's a brief list:
- Added the validation check to `__xmlman_unescape_inplace` (previously `xml_unescape_inplace`) as recommended by @nopnopnop-lavine.
- Renamed all non-prefixed functions to include the __xmlman prefix (no external change needed, all of those are internal functions).
- Added the header (License text and such).
- Corrected spacing for some lines.

For clarity, the added validation to `__xmlman_unescape_inplace` is this:
```C
if (j < len) {
    str[j] = '\0';
} else if (len > 0) {
    str[len - 1] = '\0';
}
```

This sacrifices correctness over vulnerabilities, as this fix only applies to situations where standalone calls are providing a no-op input for this function, the check then replaces the last character with the null-terminator, rather than writing *outside* the buffer. This results in incorrect output, but without any overflow.