### PR TITLE
Optimize GIF decoder with better transparency handling

### DIFF
--- a/src/IMG_gif.c
+++ b/src/IMG_gif.c
@@ -891,16 +891,18 @@ static bool IMG_AnimationDecoderGetNextFrame_Internal(IMG_AnimationDecoder *deco
                               BitSet(ctx->buf[8], INTERLACE), 0, &ctx->state);
         }
 
-        if (!image) {
-            // Incorrect animation is harder to detect than a direct failure,
-            // so it's better to fail than try to animate a GIF without a,
-            // full set of frames it has in the file.
+      if (!image) {
+          // Incorrect animation is harder to detect than a direct failure,
+          // so it's better to fail than try to animate a GIF without a,
+          // full set of frames it has in the file.
 
-            // Only set the error if ReadImage did not do it.
-            if (SDL_GetError()[0] == '\0') {
-                return SDL_SetError("Failed to decode frame.");
-            }
-        }
+          // Only set the error if ReadImage did not do it.
+          if (SDL_GetError()[0] == '\0') {
+              return SDL_SetError("Failed to decode frame.");
+          }
+
+          return false;
+      }
 
         /* Composite the frame onto the canvas */
         SDL_Rect dest = { left, top, width, height };


### PR DESCRIPTION
This patch fixes #632 as well as handling a FIXME in the invalid frame case.

Here's a brief list:
- If we fail to decode a frame of GIF, the entire decoding is set to fail. It feels like a better approach than proceeding with "Success" status and then showing an incomplete animation on the user side.
- Previously, the frames were retrieved in INDEX8 format, then blitted into an RGBA32 canvas. Now we directly create each frame as RGBA32 surfaces with transparency mapped to the appropriate alpha channel of each pixel, resulting in smooth decoding for every image.

Tested with the original rgbrgb.gif, tested with the images given by @maia-s in #632, also tested with 2 different solid and transparent GIF animations, seems to decode all of them correctly so far.