### PR TITLE
[SDL-1.2] Fix incompatible pointer type error when compiling with Clang compiler

### DIFF
--- a/IMG_png.c
+++ b/IMG_png.c
@@ -113,7 +113,7 @@ int IMG_InitPNG()
 			return -1;
 		}
 		lib.png_create_read_struct =
-			(png_structrp (*) (png_const_charp, png_voidp, png_error_ptr, png_error_ptr))
+			(png_structp (*) (png_const_charp, png_voidp, png_error_ptr, png_error_ptr))
 			SDL_LoadFunction(lib.handle, "png_create_read_struct");
 		if ( lib.png_create_read_struct == NULL ) {
 			SDL_UnloadObject(lib.handle);


### PR DESCRIPTION
Branch: `SDL-1.2`
Compiler: `Clang`

Error:
```
SDL_image/IMG_png.c:115:30: error: incompatible function pointer types assigning to
      'png_structp (*)(png_const_charp, png_voidp, png_error_ptr, png_error_ptr)' (aka 'struct png_struct_def *(*)(const char *, void *, void (*)(struct png_struct_def *, const char *), void (*)(struct png_struct_def *, const char *))')
      from 'png_structrp (*)(png_const_charp, png_voidp, png_error_ptr, png_error_ptr)' (aka 'struct png_struct_def *restrict (*)(const char *, void *, void (*)(struct png_struct_def *, const char *), void (*)(struct png_struct_def *, const
      char *))') [-Wincompatible-function-pointer-types]
  115 |                 lib.png_create_read_struct =
      |                                            ^
  116 |                         (png_structrp (*) (png_const_charp, png_voidp, png_error_ptr, png_error_ptr))
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  117 |                         SDL_LoadFunction(lib.handle, "png_create_read_struct");
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```