### PR TITLE
Patch for GIF Decoding/Encoding

### DIFF
--- a/src/IMG_gif.c
+++ b/src/IMG_gif.c
@@ -449,7 +449,7 @@ ReadImage(SDL_IOStream * src, int len, int height, int cmapSize,
     }
 
     if (state->Gif89.transparent >= 0 && state->Gif89.transparent < cmapSize) {
-        SDL_SetSurfaceColorKey(image, 1, state->Gif89.transparent);
+        SDL_SetSurfaceColorKey(image, true, state->Gif89.transparent);
     }
 
     while ((v = LWZReadByte(src, FALSE, c, state)) >= 0) {


### PR DESCRIPTION
Refactor GIF image processing to support palette management and transparency handling. This fixes #641 and #645.
Note that I could not reproduce the transparency issue with encoding using formats other than GIF.