### PR TITLE
nanosvgrast.h: update from mainstream

### DIFF
--- a/src/IMG_svg.c
+++ b/src/IMG_svg.c
@@ -64,6 +64,8 @@
 #define sqrtf   SDL_sqrtf
 #define tanf    SDL_tanf
 #define roundf  SDL_roundf
+#undef  isnan
+#define isnan   SDL_isnanf
 #ifndef FLT_MAX
 #define FLT_MAX     3.402823466e+38F
 #endif

--- a/src/nanosvgrast.h
+++ b/src/nanosvgrast.h
@@ -840,8 +840,10 @@ static void nsvg__flattenShapeStroke(NSVGrasterizer* r, NSVGshape* shape, float 
 				}
 			}
 			// Stroke any leftover path
-			if (r->npoints > 1 && dashState)
+			if (r->npoints > 1 && dashState) {
+				nsvg__prepareStroke(r, miterLimit, lineJoin);
 				nsvg__expandStroke(r, r->points, r->npoints, 0, lineJoin, lineCap, lineWidth);
+			}
 		} else {
 			nsvg__prepareStroke(r, miterLimit, lineJoin);
 			nsvg__expandStroke(r, r->points, r->npoints, closed, lineJoin, lineCap, lineWidth);
@@ -962,7 +964,11 @@ static void nsvg__fillActiveEdges(unsigned char* scanline, int len, NSVGactiveEd
 	}
 }
 
-static float nsvg__clampf(float a, float mn, float mx) { return a < mn ? mn : (a > mx ? mx : a); }
+static float nsvg__clampf(float a, float mn, float mx) {
+	if (isnan(a))
+		return mn;
+	return a < mn ? mn : (a > mx ? mx : a);
+}
 
 static unsigned int nsvg__RGBA(unsigned char r, unsigned char g, unsigned char b, unsigned char a)
 {


### PR DESCRIPTION
- Adds missing `NaN` check in `nsvg__clampf()`
- Adds missing call to `nsvg__prepareStroke()` in leftover
  stroke path in `nsvg__flattenShapeStroke()`

TODO: merge the new paint order parsing stuff [1], too?

[1] https://github.com/memononen/nanosvg/commit/d55a1fe69b1c7f41cf555a7135d54761efb1e56b
