### PR TITLE
Handle orientation metadata

### DIFF
--- a/src/IMG.c
+++ b/src/IMG.c
@@ -546,3 +546,69 @@ Uint64 IMG_TimebaseDuration(Uint64 pts, Uint64 duration, Uint64 src_numerator, U
     Uint64 b = ( ( ( pts * 2 ) + 1 ) * src_numerator * dst_denominator ) / ( 2 * src_denominator * dst_numerator );
     return (a - b);
 }
+
+SDL_Surface *IMG_ApplyOrientation(SDL_Surface *surface, int orientation)
+{
+    SDL_Surface *tmp;
+    switch (orientation)
+    {
+    case 1:
+        // Normal (no rotation required)
+        break;
+    case 2:
+        // Flipped horizontally
+        if (!SDL_FlipSurface(surface, SDL_FLIP_HORIZONTAL)) {
+            SDL_DestroySurface(surface);
+            return NULL;
+        }
+        break;
+    case 3:
+        // Upside-down (180 degrees rotation)
+        tmp = SDL_RotateSurface(surface, 180.0f);
+        SDL_DestroySurface(surface);
+        surface = tmp;
+        break;
+    case 4:
+        // Flipped vertically
+        if (!SDL_FlipSurface(surface, SDL_FLIP_VERTICAL)) {
+            SDL_DestroySurface(surface);
+            return NULL;
+        }
+        break;
+    case 5:
+        // Flip horizontally and rotate 90 degrees counterclockwise
+        if (!SDL_FlipSurface(surface, SDL_FLIP_HORIZONTAL)) {
+            SDL_DestroySurface(surface);
+            return NULL;
+        }
+        tmp = SDL_RotateSurface(surface, -90.0f);
+        SDL_DestroySurface(surface);
+        surface = tmp;
+        break;
+    case 6:
+        // Rotate 90 degrees clockwise
+        tmp = SDL_RotateSurface(surface, 90.0f);
+        SDL_DestroySurface(surface);
+        surface = tmp;
+        break;
+    case 7:
+        // Flip horizontally and rotate 90 degrees clockwise
+        if (!SDL_FlipSurface(surface, SDL_FLIP_HORIZONTAL)) {
+            SDL_DestroySurface(surface);
+            return NULL;
+        }
+        tmp = SDL_RotateSurface(surface, 90.0f);
+        SDL_DestroySurface(surface);
+        surface = tmp;
+        break;
+    case 8:
+        // Rotate 90 degrees counterclockwise
+        tmp = SDL_RotateSurface(surface, -90.0f);
+        SDL_DestroySurface(surface);
+        surface = tmp;
+        break;
+    default:
+        break;
+    }
+    return surface;
+}

--- a/src/IMG_ImageIO.m
+++ b/src/IMG_ImageIO.m
@@ -11,6 +11,8 @@
 
 #include <SDL3_image/SDL_image.h>
 
+#include "IMG_utils.h"
+
 // Used because CGDataProviderCreate became deprecated in 10.5
 #include <AvailabilityMacros.h>
 #include <TargetConditionals.h>
@@ -355,25 +357,9 @@ static SDL_Surface *Create_SDL_Surface_From_CGImage(CGImageRef image_ref, CFDict
     if (surface && properties) {
         CFNumberRef numval;
         if (CFDictionaryGetValueIfPresent(properties, kCGImagePropertyOrientation, (const void **)&numval)) {
-            float rotation = 0.0f;
             CGImagePropertyOrientation orientation;
             CFNumberGetValue(numval, kCFNumberSInt32Type, &orientation);
-            switch (orientation) {
-            case kCGImagePropertyOrientationRight:
-                rotation = 90.0f;
-                break;
-            case kCGImagePropertyOrientationDown:
-                rotation = 180.0f;
-                break;
-            case kCGImagePropertyOrientationLeft:
-                rotation = 270.0f;
-                break;
-            default:
-                break;
-            }
-            if (rotation != 0.0f) {
-                SDL_SetFloatProperty(SDL_GetSurfaceProperties(surface), SDL_PROP_SURFACE_ROTATION_FLOAT, rotation);
-            }
+            surface = IMG_ApplyOrientation(surface, orientation);
         }
     }
     return surface;

--- a/src/IMG_utils.h
+++ b/src/IMG_utils.h
@@ -1,0 +1,23 @@
+/*
+  SDL_image:  An example image loading library for use with SDL
+  Copyright (C) 1997-2026 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+*/
+
+extern SDL_Surface *IMG_ApplyOrientation(SDL_Surface *surface, int orientation);
+


### PR DESCRIPTION
This supports the orientation in TIFF files and the XMP orientation metadata in PNG files when using libpng. It does not currently support Exif metadata.

Fixes https://github.com/libsdl-org/SDL_image/issues/468