### PR TITLE
png: Only include IMG_ImageIO.h conditionally

### DIFF
--- a/src/IMG_png.c
+++ b/src/IMG_png.c
@@ -23,7 +23,10 @@
 
 #include <SDL3_image/SDL_image.h>
 
+#ifdef PNG_USES_IMAGEIO
 #include "IMG_ImageIO.h"
+#endif
+
 #include "IMG_libpng.h"
 #include "IMG_WIC.h"
 


### PR DESCRIPTION
IMG_ImageIO.{h,m} contain a copyright notice that is unlikely to be accurate (claiming that the copyright holder is named `__MyCompanyName__`), an "all rights reserved" statement and no license grant.

As a result, software distributions that are cautious about copyright (such as Debian) tend to treat it as non-open-source and potentially copyright-infringing to include in their packages, and therefore strip it out from the upstream source releases during packaging. It's only used on the macOS family, so no functionality is lost by doing this on other OSs. However, we do need to avoid including its headers if they might not even be present.

---

If you have permission from the copyright holder(s) of `IMG_ImageIO.{h,m}` to distribute them under the Zlib license, then an alternative way to solve this would be to list the actual copyright holders and license grant in those files - but I don't know who the copyright holders are (Eric Wing? Vittorio Giovara? Steaphan Greene? Their employers? Apple, for code copied from their documentation? others?) or whether they have given that permission, so I'm certainly not going to make that change myself.