### PR TITLE
IMG_libpng: adjust restrict attribute for png_noconst15_structrp

### DIFF
--- a/src/IMG_libpng.c
+++ b/src/IMG_libpng.c
@@ -99,12 +99,12 @@ typedef png_structp png_noconst15_structrp;
 typedef png_inforp png_noconst15_inforp;
 typedef png_const_inforp png_noconst16_inforp;
 #else
-typedef png_const_structp png_noconst15_structrp;
+typedef png_const_structrp png_noconst15_structrp;
 typedef png_const_inforp png_noconst15_inforp;
 typedef png_inforp png_noconst16_inforp;
 #endif
 #else
-typedef png_const_structp png_noconst15_structrp;
+typedef png_const_structrp png_noconst15_structrp;
 typedef png_const_inforp png_noconst15_inforp;
 typedef png_inforp png_noconst16_inforp;
 #endif


### PR DESCRIPTION
change the defination of png_noconst15_structrp to match the __restrict attribute.

When trying to build SDL_image with libpng18, I got warnings on L239 and some other lines complaining on type mismatch. It seems that png_const_structrp does not match png_noconst15_structrp, because the latter misses the restrict attribute. And in my building environment, changing png_const_structp to png_const_structrp fixes the warning.