### PR TITLE
Fix potential memory leak when png writing fails

### DIFF
--- a/src/IMG_libpng.c
+++ b/src/IMG_libpng.c
@@ -2101,6 +2101,7 @@ static bool SaveAPNGAnimationPushFrame(IMG_AnimationEncoder *encoder, SDL_Surfac
         SDL_memcpy(fdat_data, fdat_prefix, 4);
         SDL_memcpy(fdat_data + 4, full_zlib_data, full_zlib_size);
         if (!write_png_chunk(encoder->dst, "fdAT", fdat_data, 4 + full_zlib_size)) {
+            SDL_free(fdat_data);
             goto error;
         }
         SDL_free(fdat_data);


### PR DESCRIPTION
Adding a call to `SDL_free(fdat_data)` when `write_png_chunk()` fails.

Also refactored a bit.

<details><summary>Full warning</summary>
<p>

```
SDL_image/src/IMG_libpng.c:2123:9: warning: Potential leak of memory pointed to by 'fdat_data' [clang-analyzer-unix.Malloc]
 2123 |     if (full_zlib_data) {
      |         ^
SDL_image/src/IMG_libpng.c:1819:9: note: Assuming field 'ctx' is non-null
 1819 |     if (!encoder->ctx) {
      |         ^~~~~~~~~~~~~
SDL_image/src/IMG_libpng.c:1819:5: note: Taking false branch
 1819 |     if (!encoder->ctx) {
      |     ^
SDL_image/src/IMG_libpng.c:1825:9: note: Assuming field 'png_write_ptr' is non-null
 1825 |     if (!encoder->ctx->png_write_ptr) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL_image/src/IMG_libpng.c:1825:5: note: Taking false branch
 1825 |     if (!encoder->ctx->png_write_ptr) {
      |     ^
SDL_image/src/IMG_libpng.c:1830:9: note: Assuming 'frame' is non-null
 1830 |     if (!frame) {
      |         ^~~~~~
SDL_image/src/IMG_libpng.c:1830:5: note: Taking false branch
 1830 |     if (!frame) {
      |     ^
SDL_image/src/IMG_libpng.c:1840:9: note: Assuming field 'current_frame_index' is not equal to 0
 1840 |     if (encoder->ctx->current_frame_index == 0) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL_image/src/IMG_libpng.c:1840:5: note: Taking false branch
 1840 |     if (encoder->ctx->current_frame_index == 0) {
      |     ^
SDL_image/src/IMG_libpng.c:1893:13: note: Assuming field 'w' is equal to field 'apng_width'
 1893 |         if (frame->w != encoder->ctx->apng_width || frame->h != encoder->ctx->apng_height) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL_image/src/IMG_libpng.c:1893:13: note: Left side of '||' is false
SDL_image/src/IMG_libpng.c:1893:53: note: Assuming field 'h' is equal to field 'apng_height'
 1893 |         if (frame->w != encoder->ctx->apng_width || frame->h != encoder->ctx->apng_height) {
      |                                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL_image/src/IMG_libpng.c:1893:9: note: Taking false branch
 1893 |         if (frame->w != encoder->ctx->apng_width || frame->h != encoder->ctx->apng_height) {
      |         ^
SDL_image/src/IMG_libpng.c:1917:9: note: Assuming field 'output_pixel_format' is equal to SDL_PIXELFORMAT_INDEX8
 1917 |     if (encoder->ctx->output_pixel_format == SDL_PIXELFORMAT_INDEX8) {
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL_image/src/IMG_libpng.c:1917:5: note: Taking true branch
 1917 |     if (encoder->ctx->output_pixel_format == SDL_PIXELFORMAT_INDEX8) {
      |     ^
SDL_image/src/IMG_libpng.c:1918:13: note: Assuming field 'format' is not equal to SDL_PIXELFORMAT_INDEX8
 1918 |         if (current_frame_for_processing->format != SDL_PIXELFORMAT_INDEX8) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL_image/src/IMG_libpng.c:1918:9: note: Taking true branch
 1918 |         if (current_frame_for_processing->format != SDL_PIXELFORMAT_INDEX8) {
      |         ^
SDL_image/src/IMG_libpng.c:1920:17: note: Assuming 'final_frame_for_compression' is non-null
 1920 |             if (!final_frame_for_compression) {
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL_image/src/IMG_libpng.c:1920:13: note: Taking false branch
 1920 |             if (!final_frame_for_compression) {
      |             ^
SDL_image/src/IMG_libpng.c:1940:23: note: Field 'output_pixel_format' is equal to SDL_PIXELFORMAT_INDEX8
 1940 |     if (encoder->ctx->output_pixel_format == SDL_PIXELFORMAT_INDEX8) {
      |                       ^
SDL_image/src/IMG_libpng.c:1940:5: note: Taking true branch
 1940 |     if (encoder->ctx->output_pixel_format == SDL_PIXELFORMAT_INDEX8) {
      |     ^
SDL_image/src/IMG_libpng.c:1950:23: note: Field 'current_frame_index' is not equal to 0
 1950 |     if (encoder->ctx->current_frame_index == 0) {
      |                       ^
SDL_image/src/IMG_libpng.c:1950:5: note: Taking false branch
 1950 |     if (encoder->ctx->current_frame_index == 0) {
      |     ^
SDL_image/src/IMG_libpng.c:2065:13: note: Assuming 'full_zlib_data' is non-null
 2065 |         if (!full_zlib_data || full_zlib_size == 0) {
      |             ^~~~~~~~~~~~~~~
SDL_image/src/IMG_libpng.c:2065:13: note: Left side of '||' is false
SDL_image/src/IMG_libpng.c:2065:32: note: Assuming 'full_zlib_size' is not equal to 0
 2065 |         if (!full_zlib_data || full_zlib_size == 0) {
      |                                ^~~~~~~~~~~~~~~~~~~
SDL_image/src/IMG_libpng.c:2065:9: note: Taking false branch
 2065 |         if (!full_zlib_data || full_zlib_size == 0) {
      |         ^
SDL_image/src/IMG_libpng.c:2083:9: note: Taking false branch
 2083 |         if (!write_png_chunk(encoder->dst, "fcTL", fctl_data, 26)) {
      |         ^
SDL_image/src/IMG_libpng.c:2092:13: note: Assuming the condition is false
 2092 |         if (full_zlib_size > SDL_SIZE_MAX - 4) {
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
SDL_image/src/IMG_libpng.c:2092:9: note: Taking false branch
 2092 |         if (full_zlib_size > SDL_SIZE_MAX - 4) {
      |         ^
SDL_image/src/IMG_libpng.c:2096:32: note: Memory is allocated
 2096 |         fdat_data = (png_bytep)SDL_malloc(4 + full_zlib_size);
      |                                ^
SDL/include/SDL3/SDL_stdinc.h:6037:20: note: expanded from macro 'SDL_malloc'
 6037 | #define SDL_malloc malloc
      |                    ^
SDL_image/src/IMG_libpng.c:2097:13: note: Assuming 'fdat_data' is non-null
 2097 |         if (!fdat_data) {
      |             ^~~~~~~~~~
SDL_image/src/IMG_libpng.c:2097:9: note: Taking false branch
 2097 |         if (!fdat_data) {
      |         ^
SDL_image/src/IMG_libpng.c:2103:9: note: Taking true branch
 2103 |         if (!write_png_chunk(encoder->dst, "fdAT", fdat_data, 4 + full_zlib_size)) {
      |         ^
SDL_image/src/IMG_libpng.c:2123:9: note: Potential leak of memory pointed to by 'fdat_data'
 2123 |     if (full_zlib_data) {
      |         ^
```

</p>
</details> 
