### PR TITLE
IMG_bmp: return NULL from GetIconSurface on seek failure

### DIFF
--- a/src/IMG_bmp.c
+++ b/src/IMG_bmp.c
@@ -534,7 +534,7 @@ static SDL_Surface *GetIconSurface(SDL_IOStream *src, Sint64 offset, int type, i
     Uint32 biSize;
 
     if (SDL_SeekIO(src, offset, SDL_IO_SEEK_SET) < 0) {
-        return false;
+        return NULL;
     }
 
     if (!SDL_ReadU32LE(src, &biSize) ||
@@ -948,4 +948,3 @@ bool IMG_SaveICO(SDL_Surface *surface, const char *file)
 }
 
 #endif // SAVE_BMP
-


### PR DESCRIPTION
Fixes #700

`GetIconSurface()` returns `SDL_Surface *`, but the seek-failure path returned
`false` instead of a null pointer.

This should be equivalent on regular compilers since false is zero, but triggers `-Wbool-conversion` with Clang.

Change: Return `NULL` here to match the function return type and avoid the warning.
https://github.com/libsdl-org/SDL_image/blob/22dd4dcc5c80081d5ecda241cf1fa225bdeb85ad/src/IMG_bmp.c#L537
