### PR TITLE
xcf: fix null pointer dereference when read_xcf_hierarchy() fails

### DIFF
--- a/src/IMG_xcf.c
+++ b/src/IMG_xcf.c
@@ -751,6 +751,10 @@ do_layer_surface(SDL_Surface *surface, SDL_IOStream *src, xcf_header *head, xcf_
         return 1;
     }
     hierarchy = read_xcf_hierarchy(src, head);
+    if (!hierarchy) {
+        SDL_SetError("Failed to read XCF image hierarchy");
+        return 1;
+    }
 
     if (hierarchy->bpp > 4) {  /* unsupported. */
         SDL_SetError("Unknown Gimp image bpp (%u)", (unsigned int) hierarchy->bpp);


### PR DESCRIPTION
read_xcf_hierarchy() can return NULL when SDL_calloc() fails or when SDL_ReadU32BE() fails. The return value was not checked before dereferencing hierarchy->bpp in do_layer_surface(), causing a null pointer dereference.

Fix: add NULL check after read_xcf_hierarchy() and return 1 on failure.

CWE-476 (NULL Pointer Dereference) - Medium (CVSS 6.5)

## Affected code

```c
// src/IMG_xcf.c — do_layer_surface()
    if (SDL_SeekIO(src, layer->hierarchy_file_offset, SDL_IO_SEEK_SET) < 0) {
        return 1;
    }
    hierarchy = read_xcf_hierarchy(src, head);

    if (hierarchy->bpp > 4) {  /* unsupported. */         // <-- NULL deref
        SDL_SetError("Unknown Gimp image bpp (%u)", ...);
        free_xcf_hierarchy(hierarchy);
        return 1;
    }
```

## Fix

```diff
diff --git a/src/IMG_xcf.c b/src/IMG_xcf.c
--- a/src/IMG_xcf.c
+++ b/src/IMG_xcf.c
@@ -751,6 +751,10 @@ do_layer_surface(SDL_Surface *surface, SDL_IOStream *src, xcf_header *head, xcf_
         return 1;
     }
     hierarchy = read_xcf_hierarchy(src, head);
+    if (!hierarchy) {
+        SDL_SetError("Failed to read XCF image hierarchy");
+        return 1;
+    }
 
     if (hierarchy->bpp > 4) {  /* unsupported. */
         SDL_SetError("Unknown Gimp image bpp (%u)", (unsigned int) hierarchy->bpp);
```
