### PR TITLE
tga: reject images with zero width or height

### DIFF
--- a/src/IMG_tga.c
+++ b/src/IMG_tga.c
@@ -186,6 +186,10 @@ SDL_Surface *IMG_LoadTGA_IO(SDL_IOStream *src)
 
     w = LE16(hdr.width);
     h = LE16(hdr.height);
+    if (w == 0 || h == 0) {
+        SDL_SetError("TGA image with zero width or height");
+        return NULL;
+    }
     img = SDL_CreateSurface(w, h, format);
     if (img == NULL) {
         error = "Out of memory";


### PR DESCRIPTION
When SDL_CreateSurface() is called with w=0 or h=0, it returns a non-NULL surface but with a NULL pixels pointer. Subsequent code in IMG_LoadTGA_IO() accesses img->pixels unconditionally, resulting in undefined behavior (UBSan: applying zero offset to null pointer at IMG_tga.c:264).

Fix: reject zero-dimension images early before creating the surface.

CWE-476 (NULL Pointer Dereference) - Medium (CVSS 5.5)

## Affected code

```c
// src/IMG_tga.c — IMG_LoadTGA_IO()
    w = LE16(hdr.width);
    h = LE16(hdr.height);
    img = SDL_CreateSurface(w, h, format);   // returns non-NULL with pixels=NULL when w/h=0
    if (img == NULL) {
        error = "Out of memory";
        goto error;
    }
    ...
    if (hdr.flags & TGA_ORIGIN_UPPER) {
        lstep = img->pitch;
        dst = (Uint8 *)img->pixels;
    } else {
        lstep = -img->pitch;
        dst = (Uint8 *)img->pixels + (h - 1) * img->pitch;   // <-- UB: NULL + 0
    }
```

## Fix

```diff
diff --git a/src/IMG_tga.c b/src/IMG_tga.c
--- a/src/IMG_tga.c
+++ b/src/IMG_tga.c
@@ -185,6 +185,10 @@ SDL_Surface *IMG_LoadTGA_IO(SDL_IOStream *src)
 
     w = LE16(hdr.width);
     h = LE16(hdr.height);
+    if (w == 0 || h == 0) {
+        SDL_SetError("TGA image with zero width or height");
+        return NULL;
+    }
     img = SDL_CreateSurface(w, h, format);
     if (img == NULL) {
         error = "Out of memory";
```