### PR TITLE
gif: Default loop count to -1 when NETSCAPE extension is absent

### DIFF
--- a/src/IMG_gif.c
+++ b/src/IMG_gif.c
@@ -547,7 +547,7 @@ static bool IMG_AnimationDecoderGetGIFHeader(IMG_AnimationDecoder *decoder, char
     }
 
     if (loopCount) {
-        *loopCount = 0;
+        *loopCount = -1;
     }
 
     IMG_AnimationDecoderContext *ctx = decoder->ctx;
@@ -994,7 +994,7 @@ bool IMG_CreateGIFAnimationDecoder(IMG_AnimationDecoder *decoder, SDL_Properties
     decoder->Close = IMG_AnimationDecoderClose_Internal;
 
     char *comment = NULL;
-    int loop_count = 0;
+    int loop_count = -1;
     if (!IMG_AnimationDecoderGetGIFHeader(decoder, &comment, &loop_count)) {
         return false;
     }


### PR DESCRIPTION
We use `SDL_image` for loading GIFs in Visual Pinball and need to know the loop count.  Since the GIFs are created by table creators, many of them are missing the NETSCAPE header. When this happens, the loop count is defaulted to `0` which means loop indefinitely. We could set it to `1` so that it plays once, but I think it's better to let the user decide and return `-1` when the loop count can't be determined.

```
 IMG_AnimationDecoder* decoder = IMG_CreateAnimationDecoder_IO(io, false, nullptr);
 if (decoder)
 {
    SDL_PropertiesID props = IMG_GetAnimationDecoderProperties(decoder);
    m_loopCount = static_cast<int>(SDL_GetNumberProperty(props, IMG_PROP_METADATA_LOOP_COUNT_NUMBER, -1));
    IMG_CloseAnimationDecoder(decoder);
 }
```