### PR TITLE
gif: fix incorrect loop_count calculation

### DIFF
--- a/src/IMG_gif.c
+++ b/src/IMG_gif.c
@@ -547,7 +547,7 @@ static bool IMG_AnimationDecoderGetGIFHeader(IMG_AnimationDecoder *decoder, char
     }
 
     if (loopCount) {
-        *loopCount = 0;
+        *loopCount = 1;
     }
 
     IMG_AnimationDecoderContext *ctx = decoder->ctx;
@@ -639,7 +639,8 @@ static bool IMG_AnimationDecoderGetGIFHeader(IMG_AnimationDecoder *decoder, char
                                     return SDL_SetError("Error reading Netscape sub-block data");
                                 }
                                 if (sub_block_data[0] == 0x01 && loopCount) {
-                                    *loopCount = LM_to_uint(sub_block_data[1], sub_block_data[2]);
+                                    int repeat = LM_to_uint(sub_block_data[1], sub_block_data[2]);
+                                    *loopCount = (repeat == 0) ? 0 : repeat + 1;
                                 }
                                 // Terminator
                                 if (!ReadOK(src, &sub_block_size, 1) || sub_block_size != 0x00) {
@@ -994,7 +995,7 @@ bool IMG_CreateGIFAnimationDecoder(IMG_AnimationDecoder *decoder, SDL_Properties
     decoder->Close = IMG_AnimationDecoderClose_Internal;
 
     char *comment = NULL;
-    int loop_count = 0;
+    int loop_count = 1;
     if (!IMG_AnimationDecoderGetGIFHeader(decoder, &comment, &loop_count)) {
         return false;
     }
@@ -2649,8 +2650,11 @@ static bool AnimationEncoder_AddFrame(IMG_AnimationEncoder *encoder, SDL_Surface
             description = SDL_GetStringProperty(ctx->metadata, IMG_PROP_METADATA_DESCRIPTION_STRING, NULL);
         }
 
-        if (writeNetscapeLoopExtension(io, loopCount) != 0) {
-            goto error;
+        if (loopCount != 1) {
+            uint16_t repeat = (loopCount == 0) ? 0 : (uint16_t)(loopCount - 1);
+            if (writeNetscapeLoopExtension(io, repeat) != 0) {
+                goto error;
+            }
         }
 
         if (description) {


### PR DESCRIPTION
This PR supersedes https://github.com/libsdl-org/SDL_image/pull/725 with new logic.

The GIF89a spec has no concept of looping. When the NETSCAPE extension is present, the stored value is the number of repeats after the first play.

As of now, if the NETSCAPE extension is not present, `loop_count` will be `0` which means users trying to use this value would think they need to loop indefinitely.

The value for the `IMG_PROP_METADATA_LOOP_COUNT_NUMBER` property could be: 

  - No NETSCAPE extension: loop_count = 1 (play once)
  - NETSCAPE repeat=0: loop_count = 0 (infinite)
  - NETSCAPE repeat=N: loop_count = N+1 (total plays)

This also updates the encoder to skip writing the NETSCAPE extension if loop_count=1, ie:

  - loop_count == 1: skip NETSCAPE extension entirely (play once)
  - loop_count == 0: write NETSCAPE with repeat=0 (infinite)
  - loop_count > 1: write NETSCAPE with repeat=loop_count-1

see [here](https://github.com/libsdl-org/SDL_image/commit/38b93a90599da351c3e67cc5729aa847c12d9b99), [here](https://github.com/libsdl-org/SDL_image/pull/603), and [here](https://github.com/mirrorer/giflib/blob/fa37672085ce4b3d62c51627ab3c8cf2dda8009a/doc/whatsinagif/animation_and_transparency.html#L306-L307)

(If this is not acceptable, and we need a new `IMG_PROP_METADATA` property, I can modify this commit. At the end of the day, I just need an accurate way to know if I need to loop, and if so, how many times.)
