### PR TITLE
[GIF] Fixes for GIF_DISPOSE_RESTORE_BACKGROUND

### DIFF
--- a/src/IMG_gif.c
+++ b/src/IMG_gif.c
@@ -535,7 +535,7 @@ struct IMG_AnimationDecoderContext
     /* Frame info */
     Uint64 last_duration;        /* The duration of the previous frame */
     int last_disposal;           /* Disposal method from previous frame */
-    int restore_frame;           /* Frame to restore when using DISPOSE_PREVIOUS */
+    SDL_Rect restore_area;       /* Area to restore when using DISPOSE_RESTORE_BACKGROUND */
 
     bool ignore_props;
 };
@@ -763,7 +763,8 @@ static bool IMG_AnimationDecoderReset_Internal(IMG_AnimationDecoder *decoder)
     ctx->got_header = false;
     ctx->got_eof = false;
     ctx->last_disposal = GIF_DISPOSE_NONE;
-    ctx->restore_frame = 0;
+    SDL_Rect r = {0};
+    ctx->restore_area = r;
 
     // We don't care about metadata when resetting to re-read.
     ctx->ignore_props = true;
@@ -850,8 +851,7 @@ static bool IMG_AnimationDecoderGetNextFrame_Internal(IMG_AnimationDecoder *deco
 
         case GIF_DISPOSE_RESTORE_BACKGROUND:
         {
-            SDL_Rect rect = { 0, 0, ctx->width, ctx->height };
-            if (!SDL_FillSurfaceRect(ctx->canvas, &rect, 0)) {
+            if (!SDL_FillSurfaceRect(ctx->canvas, &ctx->restore_area, 0)) {
                 return SDL_SetError("Failed to fill canvas with background color");
             }
         } break;
@@ -875,7 +875,12 @@ static bool IMG_AnimationDecoderGetNextFrame_Internal(IMG_AnimationDecoder *deco
             if (!SDL_BlitSurface(ctx->canvas, NULL, ctx->prev_canvas, NULL)) {
                 return SDL_SetError("Failed to save current canvas for restoration");
             }
+        } else if (ctx->state.Gif89.disposal == GIF_DISPOSE_RESTORE_BACKGROUND) {
+            SDL_Rect r = { left, top, width, height };
+            ctx->restore_area = r;
         }
+
+
         Image *image;
         if (!useGlobalColormap) {
             image = ReadImage(src, width, height, bitPixel, localColorMap, grayScale,
@@ -986,7 +991,8 @@ bool IMG_CreateGIFAnimationDecoder(IMG_AnimationDecoder *decoder, SDL_Properties
     ctx->current_delay = 100;
     ctx->current_disposal = GIF_DISPOSE_NA;
     ctx->last_disposal = GIF_DISPOSE_NONE;
-    ctx->restore_frame = 0;
+    SDL_Rect r = {0};
+    ctx->restore_area = r;
 
     decoder->ctx = ctx;
     decoder->Reset = IMG_AnimationDecoderReset_Internal;


### PR DESCRIPTION
GIF_DISPOSE_RESTORE_BACKGROUND is handled incorrectly where the entire canvas is cleared to the background color instead of just the area covered by the previous frame.

This patch ignores the background color specified and clears it to RGBA(0,0,0,0) which would be least surprising to users and allows any background rendering to be visible.

The GIF spec does specify, that if there is a global color table, the background color is an index into that table - but the standard is not clear on what color to use when there is no global color table or how this should work when the background color is equal to the transparent color which is set on a per frame basis.

I've compared what browsers (chromium/firefox) and other image viewers do and there isn't much consistency - they seem to just pick a background color that suits their UI. I am able to contribute logic for getting the background color from the global color table if desired but that would result in different rendering vs all the applications I tested . The sample GIF below has a global color table with the background color being index \#0 - RGB(30,144,255) but no program rendered it that way.

References:
[Gif89a spec](https://www.w3.org/Graphics/GIF/spec-gif89a.txt)
[ImageMagick v6 Examples -- Animation Basics](https://legacy.imagemagick.org/Usage/anim_basics/#background)
Sample GIF to test background disposal: [canvas_bgnd.gif](https://legacy.imagemagick.org/Usage/anim_basics/canvas_bgnd.gif)