### PR TITLE
tiny_jpeg.h: Fix left shift int UB warning

### DIFF
--- a/src/tiny_jpeg.h
+++ b/src/tiny_jpeg.h
@@ -628,7 +628,7 @@ TJEI_FORCE_INLINE void tjei_write_bits(TJEState* state,
 
     // Push the stack.
     uint32_t nloc = *location + num_bits;
-    *bitbuffer |= (uint32_t)(bits << (32 - nloc));
+    *bitbuffer |= (uint32_t)bits << (32 - nloc);
     *location = nloc;
     while ( *location >= 8 ) {
         // Grab the most significant byte.


### PR DESCRIPTION
#### Warning:
```
SDL3_image/src/tiny_jpeg.h:631:35: runtime error: left shift of 126 by 25 places cannot be represented in type 'int'
```

https://github.com/libsdl-org/SDL_image/blob/20de661a757b36db81abc60807b7fc729982cd19/src/tiny_jpeg.h#L631

#### Warning reason
Variable `bits` is promoted to int, then shifted and the sign-bit is written to.

#### Changes:

Casting the variable `bits` to `uint32_t` before the shift.
