### PR TITLE
svg: strstr might be defined as a macro

### DIFF
--- a/src/IMG_svg.c
+++ b/src/IMG_svg.c
@@ -46,6 +46,7 @@
 #undef strncpy
 #define strncpy SDL_strlcpy
 #define strlen  SDL_strlen
+#undef strstr
 #define strstr  SDL_strstr
 #define strtol  SDL_strtol
 #define strtoll SDL_strtoll


### PR DESCRIPTION
This change fixes the following warning:
```
/home/maarten/projects/SDL_image/src/IMG_svg.c:49:9: warning: ‘strstr’ redefined
   49 | #define strstr  SDL_strstr
      |         ^~~~~~
In file included from /home/maarten/projects/SDL/include/SDL3/SDL_stdinc.h:52,
                 from /home/maarten/projects/SDL/include/SDL3/SDL.h:34,
                 from /home/maarten/projects/SDL_image/include/SDL3_image/SDL_image.h:35,
                 from /home/maarten/projects/SDL_image/src/IMG_svg.c:26:
/usr/include/string.h:380:11: note: this is the location of the previous definition
  380 | #  define strstr(HAYSTACK, NEEDLE)                      \
      |           ^~~~~~
```

glibc 2.43 defines strstr as:
```
#  define strstr(HAYSTACK, NEEDLE)                      \
  __glibc_const_generic (HAYSTACK, const char *,        \
                         strstr (HAYSTACK, NEEDLE))
```
