### PR TITLE
lbm: Fix Extra-Half-Brite usage.

### DIFF
--- a/src/IMG_lbm.c
+++ b/src/IMG_lbm.c
@@ -142,7 +142,8 @@ SDL_Surface *IMG_LoadLBM_IO(SDL_IOStream *src )
 
     nbcolors = 0;
 
-    SDL_memset( &bmhd, 0, sizeof( BMHD ) );
+    SDL_zeroa(colormap);
+    SDL_zero(bmhd);
     flagHAM = 0;
     flagEHB = 0;
 
@@ -303,7 +304,7 @@ SDL_Surface *IMG_LoadLBM_IO(SDL_IOStream *src )
         /* The 32 last colors are the same but divided by 2 */
         /* Some Amiga pictures save 64 colors with 32 last wrong colors, */
         /* they shouldn't !, and here we overwrite these 32 bad colors. */
-        if ( (nbcolors==32 || flagEHB ) && (1<<nbplanes)==64 )
+        if ( (nbplanes == 6) && (flagEHB || nbcolors <= 32) )
         {
             nbcolors = 64;
             ptr = &colormap[0];


### PR DESCRIPTION
If the caller loads an ILBM file with 64 colors, and either provided a colormap with <= 32 colors or set the Extra_Half-Brite flag, then duplicate the lower 32 entries to half-intensity versions in the upper half.

This also initializes colormap to zero unconditionally, in case this logic would otherwise touch uninitialized stack memory. Now if there's a weird file that didn't provide all 32 colors, the original and half-brite ones will just be black instead of random data.

https://en.wikipedia.org/wiki/ILBM#Extra_Half-Brite

(Also an SDL_memset for an unrelated thing was changed to SDL_zero, since I was in here anyhow.)