### PR TITLE
Allow .avif extension

### DIFF
--- a/src/IMG_anim_decoder.c
+++ b/src/IMG_anim_decoder.c
@@ -212,7 +212,7 @@ IMG_AnimationDecoder *IMG_CreateAnimationDecoderWithProperties(SDL_PropertiesID 
         result = IMG_CreateANIAnimationDecoder(decoder, props);
     } else if (SDL_strcasecmp(type, "apng") == 0 || SDL_strcasecmp(type, "png") == 0) {
         result = IMG_CreateAPNGAnimationDecoder(decoder, props);
-    } else if (SDL_strcasecmp(type, "avifs") == 0) {
+    } else if (SDL_strcasecmp(type, "avifs") == 0 || SDL_strcasecmp(type, "avif") == 0) {
         result = IMG_CreateAVIFAnimationDecoder(decoder, props);
     } else if (SDL_strcasecmp(type, "gif") == 0) {
         result = IMG_CreateGIFAnimationDecoder(decoder, props);

--- a/src/IMG_anim_encoder.c
+++ b/src/IMG_anim_encoder.c
@@ -140,7 +140,7 @@ IMG_AnimationEncoder *IMG_CreateAnimationEncoderWithProperties(SDL_PropertiesID 
         result = IMG_CreateANIAnimationEncoder(encoder, props);
     } else if (SDL_strcasecmp(type, "apng") == 0 || SDL_strcasecmp(type, "png") == 0) {
         result = IMG_CreateAPNGAnimationEncoder(encoder, props);
-    } else if (SDL_strcasecmp(type, "avifs") == 0) {
+    } else if (SDL_strcasecmp(type, "avifs") == 0 || SDL_strcasecmp(type, "avif") == 0) {
         result = IMG_CreateAVIFAnimationEncoder(encoder, props);
     } else if (SDL_strcasecmp(type, "gif") == 0) {
         result = IMG_CreateGIFAnimationEncoder(encoder, props);


### PR DESCRIPTION
I believe the correct file extension to use for AVIF files is `.avif` (as opposed to `.avifs`).
Mac will natively preview and play files that end with `.avif` and does not recognize `.avifs` as a playable media file.

Here are other sources that I think also support this:
https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/Image_types#avif_image

https://aomediacodec.github.io/av1-avif/#brands


# Further considerations:
1. Test cases read from an `.avifs` file.

2. Line 59 differs from 89 in "AVIF" vs "AVIFS". But the "WEBP" versions don't.  https://github.com/libsdl-org/SDL_image/blob/b0c94a0b1030303969ee29a88ca52ebaf87e15cb/src/IMG.c#L59 https://github.com/libsdl-org/SDL_image/blob/b0c94a0b1030303969ee29a88ca52ebaf87e15cb/src/IMG.c#L89 

3. The saving functions use "avif" https://github.com/libsdl-org/SDL_image/blob/b0c94a0b1030303969ee29a88ca52ebaf87e15cb/src/IMG.c#L390

Maybe `SDL_strcasecmp(type, "avifs") == 0` is a typo/bug when it was first written(?), but I'm not sure. At the very least, creating the decoder fails on `.avif` files.